### PR TITLE
pedantic grammar fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,8 @@ protects your work, and gives you peace of mind knowing that the BFG is <em>only
 <em>current</em> files of your project.
 </p>
 
-<p>By default the <code>HEAD</code> branch is protected, and while it's history will be cleaned, the very latest commit
-(the 'tip') is a <strong>protected commit</strong> and it's file-hierarchy won't be changed at all.</p>
+<p>By default the <code>HEAD</code> branch is protected, and while its history will be cleaned, the very latest commit
+(the 'tip') is a <strong>protected commit</strong> and its file-hierarchy won't be changed at all.</p>
 
 <p>If you want to protect the tips of several branches or tags (not just HEAD), just name them for the BFG:</p>
 


### PR DESCRIPTION
Sorry to be pedantic, but "it's" = "it is", while "its" is the possessive for "it" (just like "his" is possessive for "him", and does not require an apostrophe).

(P.S. thanks for the awesome software!)
