### PR TITLE
Abandon usage of scala.App for 'main' method...

### DIFF
--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -21,45 +21,46 @@
 package com.madgag.git.bfg.cli
 
 import com.madgag.git._
-import com.madgag.git.bfg.cleaner._
 import com.madgag.git.bfg.GitUtil._
+import com.madgag.git.bfg.cleaner._
 
-object Main extends App {
+object Main {
 
-  if (args.isEmpty) {
-    CLIConfig.parser.showUsage
-  } else {
+  def main(args: Array[String]) {
+    if (args.isEmpty) {
+      CLIConfig.parser.showUsage
+    } else {
 
-    CLIConfig.parser.parse(args, CLIConfig()) map {
-      config =>
+      CLIConfig.parser.parse(args, CLIConfig()) map {
+        config =>
 
-        tweakStaticJGitConfig(config.massiveNonFileObjects)
+          tweakStaticJGitConfig(config.massiveNonFileObjects)
 
-        if (config.gitdir.isEmpty) {
-          CLIConfig.parser.showUsage
-          Console.err.println("Aborting : " + config.repoLocation + " is not a valid Git repository.\n")
-        } else {
-          implicit val repo = config.repo
-
-          println("\nUsing repo : " + repo.getDirectory.getAbsolutePath + "\n")
-
-          // do this before implicitly initiating big-blob search
-          if (hasBeenProcessedByBFGBefore(repo)) {
-            println("\nThis repo has been processed by The BFG before! Will prune repo before proceeding - to avoid unnecessary cleaning work on unused objects...")
-            repo.git.gc.call()
-            println("Completed prune of old objects - will now proceed with the main job!\n")
-          }
-
-          if (config.definesNoWork) {
-            Console.err.println("Please specify tasks for The BFG :")
+          if (config.gitdir.isEmpty) {
             CLIConfig.parser.showUsage
+            Console.err.println("Aborting : " + config.repoLocation + " is not a valid Git repository.\n")
           } else {
-            println("Found " + config.objectProtection.fixedObjectIds.size + " objects to protect")
+            implicit val repo = config.repo
 
-            RepoRewriter.rewrite(repo, config.objectIdCleanerConfig)
+            println("\nUsing repo : " + repo.getDirectory.getAbsolutePath + "\n")
+
+            // do this before implicitly initiating big-blob search
+            if (hasBeenProcessedByBFGBefore(repo)) {
+              println("\nThis repo has been processed by The BFG before! Will prune repo before proceeding - to avoid unnecessary cleaning work on unused objects...")
+              repo.git.gc.call()
+              println("Completed prune of old objects - will now proceed with the main job!\n")
+            }
+
+            if (config.definesNoWork) {
+              Console.err.println("Please specify tasks for The BFG :")
+              CLIConfig.parser.showUsage
+            } else {
+              println("Found " + config.objectProtection.fixedObjectIds.size + " objects to protect")
+
+              RepoRewriter.rewrite(repo, config.objectIdCleanerConfig)
+            }
           }
-        }
+      }
     }
   }
-
 }

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
@@ -27,8 +27,6 @@ import com.madgag.git.bfg.test.unpackedRepo
 
 class MainSpec extends Specification {
 
-  sequential // concurrent testing against scala.App is not safe https://twitter.com/rtyley/status/340376844916387840
-
   "CLI" should {
     "not change commits unnecessarily" in new unpackedRepo("/sample-repos/exampleWithInitialCleanHistory.git.zip") {
       implicit val r = reader


### PR DESCRIPTION
Motivation for this is to remove the 'sequential' modifier for tests...
concurrent testing against scala.App is not safe:

https://twitter.com/rtyley/status/340376844916387840

...I'd rather have faster tests than the limited convenience of
scala.App. Unfortunately, the BFG uses JGit's WindowCache config to
handle large commit objects - and that is *static* config, so
concurrent tests don't work well with it:

[info] Massive commit messages should
[info] ! be handled without crash (ie LargeObjectException) if the user specifies that the repo contains massive non-file objects
[error]     ExceedsLimit: Object d8875d55c4f723e4a7caf54fe8293abfd316f2e6 exceeds 5,242,880 limit, actual size is 10,486,015 (ObjectLoader.java:191)
[error] org.eclipse.jgit.lib.ObjectLoader.getCachedBytes(ObjectLoader.java:191)
[error] org.eclipse.jgit.revwalk.RevWalk.getCachedBytes(RevWalk.java:859)
[error] org.eclipse.jgit.revwalk.RevWalk.parseNew(RevWalk.java:823)
[error] org.eclipse.jgit.revwalk.RevWalk.parseAny(RevWalk.java:809)
[error] com.madgag.git.package$RichObjectId.asRevObject(package.scala:178)
[error] com.madgag.git.bfg.cleaner.RepoRewriter$$anonfun$2.apply(RepoRewriter.scala:83)
[error] com.madgag.git.bfg.cleaner.RepoRewriter$$anonfun$2.apply(RepoRewriter.scala:83)
[error] com.madgag.git.bfg.cleaner.RepoRewriter$.createRevWalk$1(RepoRewriter.scala:83)
[error] com.madgag.git.bfg.cleaner.RepoRewriter$.rewrite(RepoRewriter.scala:89)
[error] com.madgag.git.bfg.cli.Main$$anonfun$main$1.apply(Main.scala:60)
[error] com.madgag.git.bfg.cli.Main$$anonfun$main$1.apply(Main.scala:35)
[error] com.madgag.git.bfg.cli.Main$.main(Main.scala:34)
[error] com.madgag.git.bfg.test.unpackedRepo.run(unpackedRepo.scala:43)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9$$anon$7$$anonfun$6.apply$mcV$sp(MainSpec.scala:83)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9$$anon$7$$anonfun$6.apply(MainSpec.scala:83)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9$$anon$7$$anonfun$6.apply(MainSpec.scala:83)
[error] com.madgag.git.bfg.test.unpackedRepo.ensureRemovalOf(unpackedRepo.scala:73)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9$$anon$7.<init>(MainSpec.scala:82)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9.apply(MainSpec.scala:80)
[error] com.madgag.git.bfg.cli.MainSpec$$anonfun$13$$anonfun$apply$9.apply(MainSpec.scala:80)