### PR TITLE
Report deleted & changed files at the end of the run

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentMultiMap.scala
+++ b/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentMultiMap.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012, 2013 Roberto Tyley
+ *
+ * This file is part of 'BFG Repo-Cleaner' - a tool for removing large
+ * or troublesome blobs from Git repositories.
+ *
+ * BFG Repo-Cleaner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BFG Repo-Cleaner is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/ .
+ */
+
+package com.madgag.collection.concurrent
+
+import scala.collection.TraversableOnce
+
+
+class ConcurrentMultiMap[A, B] {
+
+  val m: collection.concurrent.Map[A, ConcurrentSet[B]] = collection.concurrent.TrieMap.empty
+
+  def addBinding(key: A, value: B): this.type = {
+    val store = m.getOrElse(key, {
+      val freshStore = new ConcurrentSet[B]
+      m.putIfAbsent(key, freshStore).getOrElse(freshStore)
+    })
+    store += value
+    this
+  }
+
+  def toMap: Map[A, Set[B]] = m.toMap.mapValues(_.toSet)
+}

--- a/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentSet.scala
+++ b/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentSet.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012, 2013 Roberto Tyley
+ *
+ * This file is part of 'BFG Repo-Cleaner' - a tool for removing large
+ * or troublesome blobs from Git repositories.
+ *
+ * BFG Repo-Cleaner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BFG Repo-Cleaner is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/ .
+ */
+
+package com.madgag.collection.concurrent
+
+import scala.collection.mutable.{Set, SetLike}
+
+
+class ConcurrentSet[A] extends Set[A] with SetLike[A, ConcurrentSet[A]] {
+
+  val m: collection.concurrent.Map[A, Boolean] = collection.concurrent.TrieMap.empty
+
+  override def +=(elem: A): this.type = {
+    m.put(elem, true)
+    this
+  }
+
+  override def -=(elem: A): this.type = {
+    m.remove(elem)
+    this
+  }
+
+  override def empty: this.type = {
+    m.empty
+    this
+  }
+
+  override def contains(elem: A): Boolean = m.contains(elem)
+
+  override def iterator: Iterator[A] = m.keysIterator
+}

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/Reporter.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/Reporter.scala
@@ -1,22 +1,24 @@
 package com.madgag.git.bfg.cleaner
 
-import com.madgag.git._
-import com.madgag.git.bfg.cleaner.protection.{ProtectedObjectCensus, ProtectedObjectDirtReport}
-import com.madgag.text.Text._
-import com.madgag.text.{ByteSize, Tables}
 import java.text.SimpleDateFormat
 import java.util.Date
+
+import com.madgag.collection.concurrent.ConcurrentMultiMap
+import com.madgag.git._
+import com.madgag.git.bfg.cleaner.protection.{ProtectedObjectCensus, ProtectedObjectDirtReport}
+import com.madgag.git.bfg.model.FileName
+import com.madgag.text.Text._
+import com.madgag.text.{ByteSize, Tables, Text}
 import org.eclipse.jgit.diff.DiffEntry.ChangeType._
 import org.eclipse.jgit.diff._
 import org.eclipse.jgit.lib.FileMode._
 import org.eclipse.jgit.lib._
-import org.eclipse.jgit.revwalk.{RevWalk, RevCommit}
+import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
 import org.eclipse.jgit.transport.ReceiveCommand
-import scala.Some
+
 import scala.collection.convert.wrapAll._
 import scala.collection.immutable.SortedMap
 import scalax.file.Path
-import com.madgag.git.bfg.GitUtil._
 
 trait Reporter {
 
@@ -211,6 +213,28 @@ class CLIReporter(repo: Repository) extends Reporter {
     lazy val cacheStatsFile = reportsDir / "cache-stats.txt"
 
     val changedIds = objectIdCleaner.cleanedObjectMap()
+
+    def reportFiles[FI](fileData: ConcurrentMultiMap[FileName, FI],titleText: String, tableTitles: Product)(f: ((FileName,Set[FI])) => Product) {
+      implicit val asd = Ordering[String].on[FileName](_.string)
+
+      val dataByFilename = SortedMap[FileName, Set[FI]](fileData.toMap.toSeq: _*)
+      if (dataByFilename.nonEmpty) {
+        val lines = dataByFilename.map(f)
+
+        println(title(titleText))
+        Tables.formatTable(tableTitles, lines.toSeq).map("\t" + _).foreach(println)
+      }
+    }
+
+    reportFiles(objectIdCleaner.changesByFilename, "Changed files", ("Filename", "Before & After")) {
+      case (filename, changes) => (filename, Text.abbreviate(changes.map {case (oldId, newId) => oldId.shortName+" ⇒ "+newId.shortName}, "...").mkString(", "))
+    }
+
+    implicit val reader = objectIdCleaner.threadLocalResources.reader()
+
+    reportFiles(objectIdCleaner.deletionsByFilename, "Deleted files", ("Filename", "Git id")) {
+      case (filename, oldIds) => (filename, Text.abbreviate(oldIds.map(oldId => oldId.shortName + oldId.sizeOpt.map(size => s" (${ByteSize.format(size)})").mkString), "...").mkString(", "))
+    }
 
     println(s"\n\nIn total, ${changedIds.size} object ids were changed - a record of these will be written to:\n\n\t${mapFile.path}")
 


### PR DESCRIPTION
This should make seeing what the BFG has got up to a lot easier, and will make a dry-run mode (still not implemented) much more useful. See also https://github.com/rtyley/bfg-repo-cleaner/issues/26 &https://github.com/rtyley/bfg-repo-cleaner/issues/17#issuecomment-36127608

The new output looks like this (and it only appears if files *have* been changed, or deleted, as appropriate).

```
Changed files
-------------

	File                           Before     After
	--------------------------------------------------
	bushhidthefacts-ORIGINAL.txt | 93fd267a | 4f6f1558

Deleted files
-------------

	File        git-id     Size (bytes)
	-----------------------------------
	video.mp4 | 294f4016 | 126384
```