### PR TITLE
Add --blob-exec to run system commands

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
@@ -1,0 +1,47 @@
+package com.madgag.git.bfg.cleaner
+
+import com.google.common.io.ByteStreams
+import com.madgag.git.bfg.model.TreeBlobEntry
+import com.madgag.git.ThreadLocalObjectDatabaseResources
+import java.util.{Arrays => JavaArrays}
+import org.eclipse.jgit.lib.Constants.OBJ_BLOB
+import scala.collection.JavaConversions._
+
+trait BlobExecModifier extends TreeBlobModifier {
+
+  def command: String
+
+  val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources
+
+  def fix(entry: TreeBlobEntry) = {
+    val loader = threadLocalObjectDBResources.reader().open(entry.objectId)
+    val objectStream = loader.openStream
+    val variables = System.getenv().map { case (key, value) => s"$key=$value" }.toSeq :+
+      s"BFG_BLOB=${entry.objectId.name}"
+    val process = Runtime.getRuntime.exec(command, variables.toArray)
+
+    val bytes = ByteStreams.toByteArray(objectStream)
+    objectStream.close()
+    process.getOutputStream.write(bytes)
+    process.getOutputStream.close()
+
+    ByteStreams.copy(process.getErrorStream, System.err)
+    process.getErrorStream.close()
+
+    val newBytes = ByteStreams.toByteArray(process.getInputStream)
+    process.getInputStream.close()
+
+    val exitCode = process.waitFor()
+    if(exitCode != 0) {
+      throw new RuntimeException(s"Process exited with code $exitCode")
+    }
+
+    if(JavaArrays.equals(bytes, newBytes)) {
+      entry.withoutName
+    } else {
+      val objectId = threadLocalObjectDBResources.inserter().insert(OBJ_BLOB, newBytes)
+      entry.copy(objectId = objectId).withoutName
+    }
+  }
+
+}

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -88,6 +88,9 @@ object CLIConfig {
     opt[String]("filter-content-size-threshold").abbr("fs").valueName("<size>").text("only do file-content filtering on files smaller than <size> (default is %1$d bytes)".format(CLIConfig().filterSizeThreshold)).action {
       (v, c) => c.copy(filterSizeThreshold = ByteSize.parse(v))
     }
+    opt[String]("blob-exec").abbr("be").valueName("<cmd>").text("execute the system command for each blob").action {
+      (v, c) => c.copy(blobExec = Some(v))
+    }
     opt[String]('p', "protect-blobs-from").valueName("<refs>").text("protect blobs that appear in the most recent versions of the specified refs (default is 'HEAD')").action {
       (v, c) => c.copy(protectBlobsFromRevisions = v.split(',').toSet)
     }
@@ -128,6 +131,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
                      filenameFilters: Seq[Filter[String]] = Nil,
                      filterSizeThreshold: Int = BlobTextModifier.DefaultSizeThreshold,
                      textReplacementExpressions: Traversable[String] = List.empty,
+                     blobExec: Option[String] = None,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
                      strictObjectChecking: Boolean = false,
                      sensitiveData: Option[Boolean] = None,
@@ -172,6 +176,15 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
       }
   }
 
+  lazy val blobExecModifier: Option[BlobExecModifier] = blobExec.map {
+    execCommand =>
+      new BlobExecModifier {
+        val command = execCommand
+
+        val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources = repo.getObjectDatabase.threadLocalResources
+      }
+  }
+
   lazy val privateDataRemoval = sensitiveData.getOrElse(Seq(fileDeletion, folderDeletion, blobTextModifier).flatten.nonEmpty)
 
   lazy val objectIdSubstitutor = if (privateDataRemoval) ObjectIdSubstitutor.OldIdsPrivate else ObjectIdSubstitutor.OldIdsPublic
@@ -209,7 +222,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
       }
     }
 
-    Seq(blobsByIdRemover, blobRemover, fileDeletion, blobTextModifier).flatten
+    Seq(blobsByIdRemover, blobRemover, fileDeletion, blobTextModifier, blobExecModifier).flatten
   }
 
   lazy val definesNoWork = treeBlobCleaners.isEmpty && folderDeletion.isEmpty && treeEntryListCleaners.isEmpty


### PR DESCRIPTION
[`git-filter-branch` docs](http://git-scm.com/docs/git-filter-branch), describing BFG:

> The command options are much more restrictive than git-filter branch, and dedicated just to the tasks of removing unwanted data- e.g: --strip-blobs-bigger-than 1M.

This is true. BFG's simple and easy options are (naturally) limited to a subset of all possible data manipulations.

This change adds `--blob-exec` which can execute any system command or script, while still taking advantage of BFG's killer optimizations of (1) parallelism and (2) per-blob (rather than per-commit) rewrites. (Though it does concede the advantage  of in-process-only operations.)

Users can use any scripting language or tool; Scala, awesome though it is, isn't well-known, and most Git users -- particularly the ones doing filter-branch type stuff -- are more familiar with command line tools.

---

A few use cases:
- I want to convert all tabs in my project to spaces, via the Unix `expand` utility. (This is more than a simple regex, as it considers mid-line tab positions.)
- I want to convert all Windows line ending to Unix line endings with `dos2unix`. This is already possible with a replace expressions `\r(\n)==>$1`, though that takes some trickery to figure out.
- I want to run a code formatter like [scalariform](https://github.com/mdr/scalariform) or [js-beautify](https://github.com/beautify-web/js-beautify) on each file. 

---

There may be some improvements to this.
- Perhaps the filter options also apply?
- This uses Java's `Runtime.exec` whose tokenizer only uses spaces -- no quotes mechnanism. Git uses the default shell (somehow) in a portable way, which is nicer.
- Documentation
