### PR TITLE
Fix issue #131, slf4j StaticLoggerBinder warning caused by no impleme…

### DIFF
--- a/bfg-library/build.sbt
+++ b/bfg-library/build.sbt
@@ -1,4 +1,4 @@
 import Dependencies._
 
-libraryDependencies ++= guava :+ scalaIoFile :+ textmatching :+ scalaGit :+ jgit :+ scalaGitTest % "test"
+libraryDependencies ++= guava :+ scalaIoFile :+ textmatching :+ scalaGit :+ jgit :+ slf4jSimple :+ scalaGitTest % "test"
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,6 +10,9 @@ object Dependencies {
 
   val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % jgitVersion
 
+  // the 1.7.2 here matches slf4j-api in jgit's dependencies
+  val slf4jSimple = "org.slf4j" % "slf4j-simple" % "1.7.2"
+
   val scalaGit = "com.madgag.scala-git" %% "scala-git" % scalaGitVersion exclude("org.eclipse.jgit", "org.eclipse.jgit")
 
   val scalaGitTest = "com.madgag.scala-git" %% "scala-git-test" % scalaGitVersion


### PR DESCRIPTION
…ntation found.  Add slf4j-simple 1.7.2 to packaging.

slfj4-api is a jgit dependency, but we have to add the logger impl.  slf4j-simple (routes to System.out.println()) is good-enough.

Signed-off-by: Brett Randall <javabrett@gmail.com>