### PR TITLE
Unbound (allow multiple) file matcher options

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
@@ -41,13 +41,3 @@ class BlobReplacer(badBlobs: Set[ObjectId], blobInserter: => BlobInserter) exten
     case e => e
   }
 }
-
-
-
-
-
-
-
-
-
-

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
@@ -50,6 +50,18 @@ class MainSpec extends FlatSpec with Matchers with OptionValues with Inspectors 
     }
   }
 
+  "remove empty trees with multiple delete-files" should "work" in new unpackedRepo("/sample-repos/folder-example.git.zip") {
+    ensureRemovalFrom(commitHist()).ofCommitsThat(haveFolder("secret-files")) {
+      run("-D credentials.txt -D passwords.txt")
+    }
+  }
+
+  "remove empty trees with multiple delete-folders" should "work" in new unpackedRepo("/sample-repos/folder-example.git.zip") {
+    ensureRemovalFrom(commitHist()).ofCommitsThat(haveFolder("secret-files")) {
+      run("--delete-folders secret-files --delete-folders big-files")
+    }
+  }
+
   "removing big blobs" should "definitely still remove blobs even if they have identical size" in new unpackedRepo("/sample-repos/moreThanOneBigBlobWithTheSameSize.git.zip") {
     ensureRemovalOfBadEggs(packedBlobsOfSize(1024), (contain allElementsOf Set(abbrId("06d7"), abbrId("cb2c"))).matcher[Traversable[ObjectId]]) {
       run("--strip-blobs-bigger-than 512B")


### PR DESCRIPTION
This change allows multiple values to the four options (`--delete-files`, `--delete-folders`, `--filter-content-including` and `--filter-content-excluding`) which use the file-matcher option.  Currently these options only accept a single value, which can be cumbersome and discourage or prevent batch-cleaning in a single pass of bfg.

I added some spec tests for delete files and folders.  I couldn't see existing spec tests for the other two, nor a quick way of adding test-replacement assertions, although I'm sure that can be done.  Also the filter glob options already had backing `Seq`s, they just were able to accept multiple values, so I expect they will work.

I originally fell into a bad trap of trying to make the options themselves `Seq`s and use `scopt`'s comma-sep single-value parsing, but that falls-foul of any value containing a comma e.g. a regex glob, so breaks tests immediately.  On reflection is it better not to allow this and just use single-value-unbounded-count options and collect them in a `Seq`.
