### PR TITLE
Privacy options

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
@@ -26,7 +26,7 @@ import com.madgag.git.bfg.model.{TreeBlobEntry, _}
 import com.madgag.textmatching.TextMatcher
 import org.eclipse.jgit.lib.ObjectId
 
-class FileDeleter(fileNameMatcher: TextMatcher, blobInserter: Option[BlobInserter] = None) extends Cleaner[TreeBlobs] {
+class FileDeleter(fileNameMatcher: TextMatcher, blobInserter: => Option[BlobInserter] = None) extends Cleaner[TreeBlobs] {
   override def apply(tbs: TreeBlobs) = tbs.entries.flatMap {
     case e if !fileNameMatcher(e.filename) => Some(e)
     case e if !blobInserter.isEmpty => Some(TreeBlobEntry(FileName(e.filename + ".REMOVED.git-id"), RegularFile, blobInserter.get.insert(e.objectId.name.getBytes)))

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -157,10 +157,9 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
 
   lazy val objectChecker = if (strictObjectChecking) Some(new ObjectChecker()) else None
 
-  lazy val deletedBlobInserter = if (replaceDeletedBlobs) Some(new BlobInserter(repo.getObjectDatabase.threadLocalResources.inserter())) else None
-  
   lazy val fileDeletion: Option[Cleaner[TreeBlobs]] = deleteFiles.collect {
-    case textMatcher => new FileDeleter(textMatcher, deletedBlobInserter)
+    case textMatcher if (replaceDeletedBlobs) => new FileDeleter(textMatcher, Some(new BlobInserter(repo.getObjectDatabase.threadLocalResources.inserter())))
+    case textMatcher => new FileDeleter(textMatcher, None)
   }
 
   lazy val folderDeletion: Option[Cleaner[TreeSubtrees]] = deleteFolders.map {

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -109,7 +109,7 @@ object CLIConfig {
     opt[Unit]("no-formerly-commit-footer").text("privacy/cryptographic-safety option, don't add former commit-hashes to the commmit-log footer e.g. Former-commit-id: <replaced commit hash>").action {
       (_, c) => c.copy(addFormerCommitFooter = false)
     }
-    opt[Unit]("no-replace-blobs").text("privacy/cryptographic-safety option, substitute deleted blobs with a reference file e.g. <filename>.REMOVED.git-id file").action {
+    opt[Unit]("no-replace-blobs").text("privacy/cryptographic-safety option, don't substitute deleted blobs with a reference file e.g. <filename>.REMOVED.git-id file").action {
       (_, c) => c.copy(replaceDeletedBlobs = false)
     }
     opt[String]("massive-non-file-objects-sized-up-to").valueName("<size>").text("increase memory usage to handle over-size Commits, Tags, and Trees that are up to X in size (eg '10M')").action {

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -247,7 +247,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
 
   def describe = {
 
-    def willOrWillNot(test: Boolean) = if (!test) "* will NOT " else "* will "
+    def willOrWillNot(test: Boolean) = if (test) "* will " else "* will NOT "
       
     lazy val desc = List(
         willOrWillNot(mentionFormerCommitInRewrite) + "mention former commit-hashes in re-written commit-log messages",

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -55,6 +55,9 @@ object Main extends App {
             Console.err.println("Please specify tasks for The BFG :")
             CLIConfig.parser.showUsage
           } else {
+            println("From the supplied parameters, The BFG:")
+            println(config.describe+"\n\n")
+            
             println("Found " + config.objectProtection.fixedObjectIds.size + " objects to protect")
 
             RepoRewriter.rewrite(repo, config.objectIdCleanerConfig)

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
@@ -43,10 +43,9 @@ class MainSpec extends FlatSpec with Matchers with OptionValues with Inspectors 
     }
   }
 
-
   "removing empty trees" should "work" in new unpackedRepo("/sample-repos/folder-example.git.zip") {
     ensureRemovalFrom(commitHist()).ofCommitsThat(haveFolder("secret-files")) {
-      run("--delete-files {credentials,passwords}.txt")
+      run("--delete-files {credentials,passwords}.txt --no-replace-blobs")
     }
   }
 


### PR DESCRIPTION
Fixed #139.  See commit-log and issue for details.  Second-commit reactivates the echo of `config.describe` which was commented-out and then removed at some point.

If this is pulled, we could add some sterner output warnings about inactive privacy options if the user is performing (non-bulk) operations that could be construed to be privacy-related.

Required a test to be updated 
