### PR TITLE
Improved CLI error-message consistency, helps with some cases in #48 :

### DIFF
--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -118,7 +118,7 @@ object CLIConfig {
         c.copy(fixFilenameDuplicatesPreferring = ord)
     }
     arg[File]("<repo>") optional() action { (x, c) =>
-      c.copy(repoLocation = x) } text("file path for Git repository to clean")
+      c.copy(repoLocation = x) } text("file path for Git repository to clean (defaults to working directory)")
   }
 }
 

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -28,6 +28,7 @@ import com.madgag.git.bfg.cli.stoptrump.dontGiveUp
 object Main extends App {
 
   if (args.isEmpty) {
+    Console.err.println("Error: Please specify tasks for The BFG:")
     CLIConfig.parser.showUsage
   } else {
 
@@ -37,8 +38,8 @@ object Main extends App {
         tweakStaticJGitConfig(config.massiveNonFileObjects)
 
         if (config.gitdir.isEmpty) {
+          Console.err.println("Error: " + config.repoLocation + " is not a valid Git repository.")
           CLIConfig.parser.showUsage
-          Console.err.println("Aborting : " + config.repoLocation + " is not a valid Git repository.\n")
         } else {
           implicit val repo = config.repo
 
@@ -52,7 +53,7 @@ object Main extends App {
           }
 
           if (config.definesNoWork) {
-            Console.err.println("Please specify tasks for The BFG :")
+            Console.err.println("Error: Please specify tasks for The BFG:")
             CLIConfig.parser.showUsage
           } else {
             println("Found " + config.objectProtection.fixedObjectIds.size + " objects to protect")


### PR DESCRIPTION
- Custom errors now start with Error: and appear first, before usage block, consistent with scopt argument errors.
- Empty-args case now reports consistent with no-work case (since <repo> is optional).
- Mentioned working directory default for <repo>
