### PR TITLE
Replace ORIG_HEAD with HEAD ref (if both exist and are not equal) pri…

### DIFF
--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -46,6 +46,7 @@ object Main extends App {
           // do this before implicitly initiating big-blob search
           if (hasBeenProcessedByBFGBefore(repo)) {
             println("\nThis repo has been processed by The BFG before! Will prune repo before proceeding - to avoid unnecessary cleaning work on unused objects...")
+            replaceOrigHead(repo);
             repo.git.gc.call()
             println("Completed prune of old objects - will now proceed with the main job!\n")
           }


### PR DESCRIPTION
…or to running auto git gc.  Fixed #38.

This change is a workaround for JGit issue https://bugs.eclipse.org/bugs/show_bug.cgi?id=479697 , see notes there.  If ORIG_HEAD exists, as a result of a previous rebase, after a BFG run and git gc (must be manual, using git, not BFG or jgit), the commit pointed to it may no longer exist.  This crashes the auto-gc run by BFG on startup when prior runs are detected.

We now replace ORIG_HEAD with HEAD before running the JGit gc.  Should 479697 be fixed that would no longer be necessary.