### PR TITLE
Added call to scopt showHeader, so that BFG version-details are repor…

### DIFF
--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -40,6 +40,7 @@ object Main extends App {
           CLIConfig.parser.showUsage
           Console.err.println("Aborting : " + config.repoLocation + " is not a valid Git repository.\n")
         } else {
+          CLIConfig.parser.showHeader
           implicit val repo = config.repo
 
           println("\nUsing repo : " + repo.getDirectory.getAbsolutePath + "\n")


### PR DESCRIPTION
…ted for successful executions, as well as failed executions via showUsage.

This produces output at the start of a run with successful args-parsing like so, depending on the current branch-name and commit-hash:

```
bfg 1.12.13-SNAPSHOT (show-header-version-096fb49)

Using repo : /tmp/1463597988503-0/_sample-repos_huge10MBCommitMessage.git.zip-unpacked
```
