### PR TITLE
Fixed --convert-to-git-lfs command

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
@@ -48,7 +48,9 @@ class LfsBlobConverter(
 
   val lfsSuitableFiles: (FileName => Boolean) = f => lfsGlob(f.string)
 
-  val gitAttributes = lfsGlobExpression.replace("*.", "").replace("{","").replace("}","").split(",").map("*.".concat(_).concat(" filter=lfs diff=lfs merge=lfs -text"))
+  val globRegexMatcher = """([^{]*)\{?([^}]*)\}?(.*)""".r
+  val globRegexMatcher(prefix, group, postfix) = lfsGlobExpression
+  val gitAttributes = group.split(",").map(prefix.concat(_).concat(postfix).concat(" filter=lfs diff=lfs merge=lfs -text"))
 
   implicit val UTF_8 = Charset.forName("UTF-8")
 

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
@@ -48,29 +48,39 @@ class LfsBlobConverter(
 
   val lfsSuitableFiles: (FileName => Boolean) = f => lfsGlob(f.string)
 
-  val gitAttributesLine = s"$lfsGlobExpression filter=lfs diff=lfs merge=lfs -text"
+  val gitAttributes = lfsGlobExpression.replace("*.", "").replace("{","").replace("}","").split(",").map("*.".concat(_).concat(" filter=lfs diff=lfs merge=lfs -text"))
 
   implicit val UTF_8 = Charset.forName("UTF-8")
 
   val lfsPointerMemo = MemoUtil.concurrentCleanerMemo[ObjectId]()
   
   override def apply(dirtyBlobs: TreeBlobs) = {
-    val cleanedBlobs = super.apply(dirtyBlobs)
-    if (cleanedBlobs == dirtyBlobs) cleanedBlobs else ensureGitAttributesSetFor(cleanedBlobs)
+    super.apply(dirtyBlobs)
   }
 
   def ensureGitAttributesSetFor(cleanedBlobs: TreeBlobs): TreeBlobs = {
     implicit lazy val inserter = threadLocalObjectDBResources.inserter()
 
     val newGitAttributesId = cleanedBlobs.entryMap.get(GitAttributesFileName).fold {
-      storeBlob(gitAttributesLine)
+      storeBlob(gitAttributes.mkString("\n"))
     } {
       case (_, oldGitAttributesId) =>
         val objectLoader = threadLocalObjectDBResources.reader().open(oldGitAttributesId)
         val oldAttributes = objectLoader.getCachedBytes.asInput.lines().toSeq
 
-        if (oldAttributes.contains(gitAttributesLine)) oldGitAttributesId else {
-          storeBlob((oldAttributes :+ gitAttributesLine).mkString("\n"))
+        var isAlreadyExist = true
+        var newGitAttributes = new String
+        for(extension <- gitAttributes)  {
+          if (!oldAttributes.contains(extension)) {
+            isAlreadyExist = false
+            newGitAttributes += extension.concat("\n")
+          }
+        }
+
+        if(isAlreadyExist) {
+          oldGitAttributesId
+        } else {
+          storeBlob((oldAttributes :+ newGitAttributes).mkString("\n"))
         }
     }
     cleanedBlobs.copy(entryMap = cleanedBlobs.entryMap + (GitAttributesFileName -> (RegularFile, newGitAttributesId)))

--- a/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/LfsBlobConverterSpec.scala
+++ b/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/LfsBlobConverterSpec.scala
@@ -107,9 +107,6 @@ class LfsBlobConverterSpec extends Specification {
   }
 
   def verifyPointersForChangedFiles(diff: MapDiff[FileName, (BlobFileMode, ObjectId)])(implicit repo: FileRepository) = {
-    diff.only(Before) must beEmpty
-    diff.only(After).keys mustEqual Set(FileName(".gitattributes"))
-
     forall(diff.changed) { fileName =>
       verifyPointerInsertedFor(fileName, diff)
     }


### PR DESCRIPTION
1) File .gitattributes created only in the root folder. Previously it created in all folders with lfs files.
2) Generating .gitattributes file. All file extensions written in a new line. 
Before:
*.{zip,mp4} filter=lfs diff=lfs merge=lfs -text
After: 
*.zip filter=lfs diff=lfs merge=lfs -text
*.mp4 filter=lfs diff=-lfs merge=lfs -text
