### PR TITLE
Projects bfg and bfg-test should depend on jgit directly, rather than…

### DIFF
--- a/bfg-test/build.sbt
+++ b/bfg-test/build.sbt
@@ -1,4 +1,4 @@
 import Dependencies._
 
-libraryDependencies ++= Seq(specs2, scalaGit, scalaGitTest)
+libraryDependencies ++= Seq(specs2, jgit, scalaGit, scalaGitTest)
 

--- a/bfg/build.sbt
+++ b/bfg/build.sbt
@@ -46,6 +46,7 @@ addArtifact( Artifact("bfg", "usage", "txt"), cliUsageDump )
 
 libraryDependencies ++= Seq(
   scopt,
+  jgit,
   scalaGitTest % "test"
 )
 


### PR DESCRIPTION
… getting the dependency transiently from scalaGit or scalaGitTest. Fixed #161.