### PR TITLE
Add --strip-trees-with-ids option

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/treeblobs.scala
@@ -34,6 +34,10 @@ class BlobRemover(blobIds: Set[ObjectId]) extends Cleaner[TreeBlobs] {
   override def apply(treeBlobs: TreeBlobs) = treeBlobs.entries.filter(e => !blobIds.contains(e.objectId))
 }
 
+class SubtreeRemover(blobIds: Set[ObjectId]) extends Cleaner[TreeSubtrees] {
+  override def apply(subtrees: TreeSubtrees) = TreeSubtrees(subtrees.entryMap.filter(e => !blobIds.contains(e._2)))
+}
+
 class BlobReplacer(badBlobs: Set[ObjectId], blobInserter: => BlobInserter) extends Cleaner[TreeBlobs] {
   override def apply(treeBlobs: TreeBlobs) = treeBlobs.entries.map {
     case e if badBlobs.contains(e.objectId) =>

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -68,6 +68,9 @@ object CLIConfig {
     opt[File]("strip-blobs-with-ids").abbr("bi").valueName("<blob-ids-file>").text("strip blobs with the specified Git object ids").action {
       (v, c) => c.copy(stripBlobsWithIds = Some(v.lines().map(_.trim).filterNot(_.isEmpty).map(_.asObjectId).toSet))
     }
+    opt[File]("strip-trees-with-ids").valueName("<tree-ids-file>").text("strip trees with the specified Git object ids").action {
+      (v, c) => c.copy(stripSubtreesWithIds = Some(v.lines().map(_.trim).filterNot(_.isEmpty).map(_.asObjectId).toSet))
+    }
     fileMatcher("delete-files").abbr("D").text("delete files with the specified names (eg '*.class', '*.{txt,log}' - matches on file name, not path within repo)").action {
       (v, c) => c.copy(deleteFiles = Some(v))
     }
@@ -132,6 +135,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
                      filterSizeThreshold: Int = BlobTextModifier.DefaultSizeThreshold,
                      textReplacementExpressions: Traversable[String] = List.empty,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
+                     stripSubtreesWithIds: Option[Set[ObjectId]] = None,
                      lfsConversion: Option[String] = None,
                      strictObjectChecking: Boolean = false,
                      sensitiveData: Option[Boolean] = None,
@@ -220,7 +224,13 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
     Seq(blobsByIdRemover, blobRemover, fileDeletion, blobTextModifier, lfsBlobConverter).flatten
   }
 
-  lazy val definesNoWork = treeBlobCleaners.isEmpty && folderDeletion.isEmpty && treeEntryListCleaners.isEmpty
+  lazy val treeSubtreesCleaners: Seq[Cleaner[TreeSubtrees]] = {
+    lazy val subtreesByIdRemover: Option[SubtreeRemover] = stripSubtreesWithIds.map(new SubtreeRemover(_))
+
+    Seq(subtreesByIdRemover, folderDeletion).flatten
+  }
+
+  lazy val definesNoWork = treeBlobCleaners.isEmpty && treeSubtreesCleaners.isEmpty && treeEntryListCleaners.isEmpty
 
   def objectIdCleanerConfig: ObjectIdCleaner.Config =
     ObjectIdCleaner.Config(
@@ -229,7 +239,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
       commitNodeCleaners,
       treeEntryListCleaners,
       treeBlobCleaners,
-      folderDeletion.toSeq,
+      treeSubtreesCleaners,
       objectChecker
     )
 


### PR DESCRIPTION
I was looking for a _reliable_ way to strip a directory based on its path, and this is a quick solution I came up with (since you said in #79 the proper built-in way would be hard to implement).

This simply adds a `--strip-trees-with-ids` option, based on what `--strip-blobs-with-ids` does. You _may_ prefer to merge both of these options into a single one, but I didn't want to break existing behavior.

Here's how it's supposed to be used:

``` bash
git rev-list --all --objects | git cat-file --batch-check='%(objectname) %(objecttype) %(rest)' | grep -Pe '^\w+ tree path/to/the/directory/to/delete$' | cut -d' ' -f1 > ./to-delete.txt
java -jar bfg.jar --no-blob-protection --strip-trees-with-ids ./to-delete.txt
```

This is _much_ more reliable than the solution in my previous comment [here](https://github.com/rtyley/bfg-repo-cleaner/issues/12#issuecomment-233701287), since it _only_ discards the subtrees, which means if any blob is also used in a _different_ path you don't intent to delete, it won't be affected.

Please note that I _absolutely_ don't know anything about Scala, and just hacked it together without really knowing what I was doing so please bear with me :smile: 
