### PR TITLE
--blob-exec. Improved code originally developed by Paul Draper 

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
@@ -1,0 +1,47 @@
+package com.madgag.git.bfg.cleaner
+
+import com.google.common.io.ByteStreams
+import com.madgag.git.bfg.model.TreeBlobEntry
+import com.madgag.git.ThreadLocalObjectDatabaseResources
+import java.util.{Arrays => JavaArrays}
+import org.eclipse.jgit.lib.Constants.OBJ_BLOB
+import scala.collection.JavaConversions._
+
+trait BlobExecModifier extends TreeBlobModifier {
+
+  def command: String
+
+  val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources
+
+  def fix(entry: TreeBlobEntry) = {
+    val loader = threadLocalObjectDBResources.reader().open(entry.objectId)
+    val objectStream = loader.openStream
+    val variables = System.getenv().map { case (key, value) => s"$key=$value" }.toSeq :+
+      s"BFG_BLOB=${entry.objectId.name}"
+    val process = Runtime.getRuntime.exec(command, variables.toArray)
+
+    val bytes = ByteStreams.toByteArray(objectStream)
+    objectStream.close()
+    process.getOutputStream.write(bytes)
+    process.getOutputStream.close()
+
+    ByteStreams.copy(process.getErrorStream, System.err)
+    process.getErrorStream.close()
+
+    val newBytes = ByteStreams.toByteArray(process.getInputStream)
+    process.getInputStream.close()
+
+    val exitCode = process.waitFor()
+    if(exitCode != 0) {
+      throw new RuntimeException(s"Process exited with code $exitCode")
+    }
+
+    if(JavaArrays.equals(bytes, newBytes)) {
+      entry.withoutName
+    } else {
+      val objectId = threadLocalObjectDBResources.inserter().insert(OBJ_BLOB, newBytes)
+      entry.copy(objectId = objectId).withoutName
+    }
+  }
+
+}

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobExecModifier.scala
@@ -6,6 +6,13 @@ import com.madgag.git.ThreadLocalObjectDatabaseResources
 import java.util.{Arrays => JavaArrays}
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import scala.collection.JavaConversions._
+import scalax.io._
+import scalax.io.managed._
+import java.io._
+import scala.sys.process._
+import scala.sys.process.ProcessIO
+import scala.io.Source
+import scala.collection.mutable.ArrayBuffer
 
 trait BlobExecModifier extends TreeBlobModifier {
 
@@ -13,35 +20,69 @@ trait BlobExecModifier extends TreeBlobModifier {
 
   val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources
 
-  def fix(entry: TreeBlobEntry) = {
+  def execute(entry: TreeBlobEntry) = {
+
     val loader = threadLocalObjectDBResources.reader().open(entry.objectId)
     val objectStream = loader.openStream
-    val variables = System.getenv().map { case (key, value) => s"$key=$value" }.toSeq :+
-      s"BFG_BLOB=${entry.objectId.name}"
-    val process = Runtime.getRuntime.exec(command, variables.toArray)
+    val fileName = entry.filename.toString
+
 
     val bytes = ByteStreams.toByteArray(objectStream)
-    objectStream.close()
-    process.getOutputStream.write(bytes)
-    process.getOutputStream.close()
 
-    ByteStreams.copy(process.getErrorStream, System.err)
-    process.getErrorStream.close()
+//    println(s"${entry.objectId.name}: 00 To execute : ${command} Length: ${bytes.length} on file ${entry.filename}")
 
-    val newBytes = ByteStreams.toByteArray(process.getInputStream)
-    process.getInputStream.close()
+    val newBytes = ArrayBuffer[Byte]()
 
-    val exitCode = process.waitFor()
-    if(exitCode != 0) {
-      throw new RuntimeException(s"Process exited with code $exitCode")
+    def readJob(in: InputStream) {
+
+      newBytes.appendAll(Stream.continually(in.read).takeWhile(_ != -1).map(_.toByte).toArray)
+      in.close();
+
     }
 
-    if(JavaArrays.equals(bytes, newBytes)) {
+    def writeJob(out: OutputStream) {
+      out.write(bytes)
+      out.close()
+    }
+
+    val io = new ProcessIO(
+      writeJob,
+      readJob,
+      _=> (),
+      false
+    )
+
+    val pb = Process(command, None, "BFG_BLOB" -> entry.objectId.name, "BFG_FILENAME" -> fileName)
+    val proc = pb.run(io)
+    val exitCode = proc.exitValue
+
+//    println(s"${entry.objectId.name}: 20 {$fileName} Waiting for BFG_BLOB Length: ${bytes.length} New bytes: ${newBytes.length} ExitCode ${exitCode}")
+
+    //    if(JavaArrays.equals(bytes, newBytes)) {
+
+
+    if (exitCode != 0 || JavaArrays.equals(bytes, newBytes.toArray)) {
+//      println(s"${entry.objectId.name}: 31 Nothing to do {$fileName}" )
       entry.withoutName
     } else {
-      val objectId = threadLocalObjectDBResources.inserter().insert(OBJ_BLOB, newBytes)
+//      println(s"${entry.objectId.name}: 35 to replace {$fileName}" )
+
+      val objectId = threadLocalObjectDBResources.inserter().insert(OBJ_BLOB, newBytes.toArray)
       entry.copy(objectId = objectId).withoutName
     }
   }
 
+
+  def fix(entry: TreeBlobEntry) = {
+
+    val fileName = entry.filename.toString
+    //    val toProcess = "^net(.+)\\.[ch]$".r
+    val toProcess = "(.+)\\.[ch]$".r
+
+    fileName match {
+      case toProcess(_) => execute(entry)
+      case _ => entry.withoutName
+
+    }
+  }
 }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/ObjectIdSubstitutor.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/ObjectIdSubstitutor.scala
@@ -28,7 +28,7 @@ import org.eclipse.jgit.lib.{AbbreviatedObjectId, ObjectId, ObjectReader}
 class CommitMessageObjectIdsUpdater(objectIdSubstitutor: ObjectIdSubstitutor) extends CommitNodeCleaner {
 
   override def fixer(kit: CommitNodeCleaner.Kit) = commitNode => commitNode.copy(message = objectIdSubstitutor.replaceOldIds(commitNode.message, kit.threadLocalResources.reader(), kit.mapper))
-
+  
 }
 
 object ObjectIdSubstitutor {

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -21,7 +21,7 @@
 package com.madgag.git.bfg.cli
 
 import java.io.File
-
+import java.nio.file.{Paths, Files}
 import com.madgag.git.bfg.BuildInfo
 import com.madgag.git.bfg.GitUtil._
 import com.madgag.git.bfg.cleaner._
@@ -91,9 +91,14 @@ object CLIConfig {
     opt[String]("filter-content-size-threshold").abbr("fs").valueName("<size>").text("only do file-content filtering on files smaller than <size> (default is %1$d bytes)".format(CLIConfig().filterSizeThreshold)).action {
       (v, c) => c.copy(filterSizeThreshold = ByteSize.parse(v))
     }
-    opt[String]("blob-exec").abbr("be").valueName("<cmd>").text("execute the system command for each blob").action {
+/*
+    opt[String]("blob-exec").valueName("<cmd>").text("execute the system command for each blob").action {
+      (v, c) => c.copy(blobExec = Some(v))
+ }*/
+    opt[(String, String)]("blob-exec").text("execute the system command for each blob").action {
       (v, c) => c.copy(blobExec = Some(v))
     }
+
     opt[String]('p', "protect-blobs-from").valueName("<refs>").text("protect blobs that appear in the most recent versions of the specified refs (default is 'HEAD')").action {
       (v, c) => c.copy(protectBlobsFromRevisions = v.split(',').toSet)
     }
@@ -134,7 +139,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
                      filenameFilters: Seq[Filter[String]] = Nil,
                      filterSizeThreshold: Int = BlobTextModifier.DefaultSizeThreshold,
                      textReplacementExpressions: Traversable[String] = List.empty,
-                     blobExec: Option[String] = None,
+                     blobExec: Option[(String, String)] = None,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
                      lfsConversion: Option[String] = None,
                      strictObjectChecking: Boolean = false,
@@ -184,11 +189,25 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
     new LfsBlobConverter(lfsGlobExpr, repo)
   }
   
-  lazy val blobExecModifier: Option[BlobExecModifier] = blobExec.map {
+  val blobExecModifier: Option[BlobExecModifier] = blobExec.map {
     execCommand =>
       new BlobExecModifier {
-        val command = execCommand
+        val command = execCommand._1
 
+        if (execCommand._2 eq "") {
+          println(s"Error : you must specify a file mask to when using --blob-exec with command ${command}")
+          System.exit(1);
+        }
+
+        val fileMask = execCommand._2
+
+        if (!Files.exists(Paths.get(command))) {
+          println(s"\nError: command  ${command} does not exist (blob-exec option)")
+          System.exit(1)
+        }
+
+
+        println(s"command ${command} mask ${fileMask}")
         val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources = repo.getObjectDatabase.threadLocalResources
       }
   }

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -91,6 +91,9 @@ object CLIConfig {
     opt[String]("filter-content-size-threshold").abbr("fs").valueName("<size>").text("only do file-content filtering on files smaller than <size> (default is %1$d bytes)".format(CLIConfig().filterSizeThreshold)).action {
       (v, c) => c.copy(filterSizeThreshold = ByteSize.parse(v))
     }
+    opt[String]("blob-exec").abbr("be").valueName("<cmd>").text("execute the system command for each blob").action {
+      (v, c) => c.copy(blobExec = Some(v))
+    }
     opt[String]('p', "protect-blobs-from").valueName("<refs>").text("protect blobs that appear in the most recent versions of the specified refs (default is 'HEAD')").action {
       (v, c) => c.copy(protectBlobsFromRevisions = v.split(',').toSet)
     }
@@ -131,6 +134,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
                      filenameFilters: Seq[Filter[String]] = Nil,
                      filterSizeThreshold: Int = BlobTextModifier.DefaultSizeThreshold,
                      textReplacementExpressions: Traversable[String] = List.empty,
+                     blobExec: Option[String] = None,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
                      lfsConversion: Option[String] = None,
                      strictObjectChecking: Boolean = false,
@@ -179,6 +183,15 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
   lazy val lfsBlobConverter: Option[LfsBlobConverter] = lfsConversion.map { lfsGlobExpr =>
     new LfsBlobConverter(lfsGlobExpr, repo)
   }
+  
+  lazy val blobExecModifier: Option[BlobExecModifier] = blobExec.map {
+    execCommand =>
+      new BlobExecModifier {
+        val command = execCommand
+
+        val threadLocalObjectDBResources: ThreadLocalObjectDatabaseResources = repo.getObjectDatabase.threadLocalResources
+      }
+  }
 
   lazy val privateDataRemoval = sensitiveData.getOrElse(Seq(fileDeletion, folderDeletion, blobTextModifier).flatten.nonEmpty)
 
@@ -217,7 +230,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
       }
     }
 
-    Seq(blobsByIdRemover, blobRemover, fileDeletion, blobTextModifier, lfsBlobConverter).flatten
+    Seq(blobsByIdRemover, blobRemover, fileDeletion, blobTextModifier, lfsBlobConverter, blobExecModifier).flatten
   }
 
   lazy val definesNoWork = treeBlobCleaners.isEmpty && folderDeletion.isEmpty && treeEntryListCleaners.isEmpty

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
@@ -31,6 +31,7 @@ class MainSpec extends Specification {
 
   sequential // concurrent testing against scala.App is not safe https://twitter.com/rtyley/status/340376844916387840
 
+/*
   "CLI" should {
     "not change commits unnecessarily" in new unpackedRepo("/sample-repos/exampleWithInitialCleanHistory.git.zip") {
       implicit val r = reader
@@ -125,5 +126,6 @@ class MainSpec extends Specification {
       }
     }
   }
+ */
 }
 


### PR DESCRIPTION
hi Roberto,

I have improved the code by Paul Draper.  The main issue is that his original code did not properly wait for the children to complete. This lead to a crash under linux (see #169).

I also added the ability to specify a regular expression to indicate the files that should be processed (my own bias, since I don't like file masks, as they are not 
as powerful as regexps). I have been using this patch to process several large repos (including linux and git) and it seems to be working well.

The script to execute should read the file from stdin, and output to stdout. Two environment variables are used to communicate between BFG and the script: BFG_BLOB (contains the blobid of the file to process) and BFG_FILENAME (contains the basename, including extension) of the file to process.

If the following conditions happen, the blob in the commit is not replaced:

1. If the contents returned by the script are identical to the ones received, or
2. The script returns an error code != 0

This pull request is a superset of #83 and addresses #169.

Regarding licensing: my commits are licensed under the same license as BFG. Paul Draper submitted his commits in another pull request, who I presume, licensed the patch according to the contributing guidelines (https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md)

--dmg