### PR TITLE
Upgraded to sbt 1.0.2, resolves console problems per https://github.c…

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.0.2


### PR DESCRIPTION
…om/sbt/sbt/issues/3453 .

I note that the upgrade to sbt 1.0.1 was recently completed on trunk.  This creates an annoying terminal issue on some shells per the linked bug, which is already fixed in sbt 1.0.2.  If anyone gets this, a workaround is to type (in the blind) "stty sane".

I wasn't sure if this should be accompanied by another Scala version bump, but looks like not ready for 2.12.x yet.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

- [x] I assign the copyright on this contribution to Roberto Tyley

