### PR TITLE
Change ByteSize.parse to return Long instead of Int

### DIFF
--- a/bfg-library/src/main/scala/com/madgag/git/bfg/GitUtil.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/GitUtil.scala
@@ -48,11 +48,11 @@ trait CleaningMapper[V] extends Cleaner[V] {
 
 object GitUtil {
   
-  val ProbablyNoNonFileObjectsOverSizeThreshold = 1024 * 1024
+  val ProbablyNoNonFileObjectsOverSizeThreshold: Long = 1024 * 1024
   
-  def tweakStaticJGitConfig(massiveNonFileObjects: Option[Int]) {
+  def tweakStaticJGitConfig(massiveNonFileObjects: Option[Long]) {
     val wcConfig: WindowCacheConfig = new WindowCacheConfig()
-    wcConfig.setStreamFileThreshold(massiveNonFileObjects.getOrElse(ProbablyNoNonFileObjectsOverSizeThreshold))
+    wcConfig.setStreamFileThreshold(massiveNonFileObjects.getOrElse(ProbablyNoNonFileObjectsOverSizeThreshold).toInt)
     wcConfig.install()
   }
 

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/GitUtil.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/GitUtil.scala
@@ -28,6 +28,7 @@ import org.eclipse.jgit.lib.ObjectReader._
 import org.eclipse.jgit.lib._
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.storage.file.WindowCacheConfig
+import com.google.common.primitives.Ints
 
 import scala.collection.convert.wrapAsScala._
 import scala.language.implicitConversions
@@ -52,7 +53,7 @@ object GitUtil {
   
   def tweakStaticJGitConfig(massiveNonFileObjects: Option[Long]) {
     val wcConfig: WindowCacheConfig = new WindowCacheConfig()
-    wcConfig.setStreamFileThreshold(massiveNonFileObjects.getOrElse(ProbablyNoNonFileObjectsOverSizeThreshold).toInt)
+    wcConfig.setStreamFileThreshold(Ints.saturatedCast(massiveNonFileObjects.getOrElse(ProbablyNoNonFileObjectsOverSizeThreshold)))
     wcConfig.install()
   }
 

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobTextModifier.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobTextModifier.scala
@@ -31,7 +31,7 @@ import scalax.io.Resource
 
 object BlobTextModifier {
 
-  val DefaultSizeThreshold = 1024 * 1024
+  val DefaultSizeThreshold: Long = 1024 * 1024
 
 }
 

--- a/bfg-library/src/main/scala/com/madgag/text/ByteSize.scala
+++ b/bfg-library/src/main/scala/com/madgag/text/ByteSize.scala
@@ -27,9 +27,9 @@ object ByteSize {
   val magnitudeChars = Seq('B', 'K', 'M', 'G', 'T', 'P')
   val unit = 1024
 
-  def parse(v: String): Int = magnitudeChars.indexOf(v.takeRight(1)(0).toUpper) match {
+  def parse(v: String): Long = magnitudeChars.indexOf(v.takeRight(1)(0).toUpper) match {
     case -1 => throw new IllegalArgumentException(s"Size unit is missing (ie ${magnitudeChars.mkString(", ")})")
-    case index => v.dropRight(1).toInt << (index * 10)
+    case index => v.dropRight(1).toLong << (index * 10)
   }
 
   def format(bytes: Long): String = {

--- a/bfg-library/src/test/scala/com/madgag/text/ByteSizeSpecs.scala
+++ b/bfg-library/src/test/scala/com/madgag/text/ByteSizeSpecs.scala
@@ -30,8 +30,19 @@ class ByteSizeSpecs extends Specification {
       ByteSize.parse("2B") mustEqual 2
       ByteSize.parse("10B") mustEqual 10
     }
+    "understand 1G" in {
+      ByteSize.parse("1G") mustEqual 1024 * 1024 * 1024
+    }
+    "understand 3G" in {
+      ByteSize.parse("3G") mustEqual 3L * 1024 * 1024 * 1024 // 3221225472
+      ByteSize.parse("3G") mustNotEqual -1073741824 // should be 3221225472 if not for Int overflow
+    }
     "understand 1M" in {
       ByteSize.parse("1M") mustEqual 1024 * 1024
+    }
+    "understand 3500M" in {
+      ByteSize.parse("3500M") mustEqual 3500L * 1024 * 1024 // 3670016000
+      ByteSize.parse("3500M") mustNotEqual -624951296 // should be 3670016000 if not for Int overflow
     }
     "understand 1K" in {
       ByteSize.parse("1K") mustEqual 1024

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -123,19 +123,19 @@ object CLIConfig {
 }
 
 case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
-                     stripBlobsBiggerThan: Option[Int] = None,
+                     stripBlobsBiggerThan: Option[Long] = None,
                      protectBlobsFromRevisions: Set[String] = Set("HEAD"),
                      deleteFiles: Option[TextMatcher] = None,
                      deleteFolders: Option[TextMatcher] = None,
                      fixFilenameDuplicatesPreferring: Option[Ordering[FileMode]] = None,
                      filenameFilters: Seq[Filter[String]] = Nil,
-                     filterSizeThreshold: Int = BlobTextModifier.DefaultSizeThreshold,
+                     filterSizeThreshold: Long = BlobTextModifier.DefaultSizeThreshold,
                      textReplacementExpressions: Traversable[String] = List.empty,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
                      lfsConversion: Option[String] = None,
                      strictObjectChecking: Boolean = false,
                      sensitiveData: Option[Boolean] = None,
-                     massiveNonFileObjects: Option[Int] = None,
+                     massiveNonFileObjects: Option[Long] = None,
                      repoLocation: File = new File(System.getProperty("user.dir"))) {
 
   lazy val gitdir = resolveGitDirFor(repoLocation)


### PR DESCRIPTION
See #232 for bug discussion.  Added a failing test in the first commit.

There's one usage of the parser that requires `Int` ... I just converted it back rather than making two parse methods.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

_(choose 1 of these 2 options)_

- [X] I assign the copyright on this contribution to Roberto Tyley

