### PR TITLE
Updated BUILD.md required Java version

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ can run anywhere Java can.
 Here's a rough set of instructions for building the BFG, if you don't want to use the
 pre-built [downloads](http://rtyley.github.io/bfg-repo-cleaner/#download):
 
-* Install Java 6 or above
+* Install Java JDK7 or above
 * Install [sbt](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html#installing-sbt)
 * `git clone git@github.com:rtyley/bfg-repo-cleaner.git`
 * `cd bfg-repo-cleaner`


### PR DESCRIPTION
BFG v1.12.3 was the last version to support Java 6.  Also make it clear that a JDK is required, not Java/JRE.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

_(choose 1 of these 2 options)_

- [X] I assign the copyright on this contribution to Roberto Tyley
- [ ] I disclaim copyright and thus place this contribution in the public domain

