### PR TITLE
Java 7 -> JDK8, updated Java dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@ Roberto's creations (<a href="https://play.google.com/store/apps/details?id=com.
 </p>
 <h1>Requirements</h1>
 <ul>
-<li>The <a href="http://java.com/en/download/manual.jsp">Java Runtime Environment</a> (Java 7 or above - BFG <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.3/bfg-1.12.3.jar">v1.12.3</a> was the last version to support Java 6)</li>
+<li>The <a href="http://java.com/en/download/manual.jsp">Java SE Development Kit (JDK8)</a> (JDK8 or above - BFG <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.9/bfg-1.12.9.jar">v1.12.9</a> was the last version to support Java 7), and BFG <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.3/bfg-1.12.3.jar">v1.12.3</a> was the last version to support Java 6)</li>
 </ul>
 <p>That's it - the Scala library and all other dependencies are folded into the <a class="latest-download-link" data-event-category="Requirements Link" href="#download">downloadable jar</a>.</p>
 


### PR DESCRIPTION
I know JDK is required for dev - maybe runtime can run with a JRE, but probably simpler to just say JDK8?  Either way 7 is no good as of the most-recent release, as already noted in developer docs.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

_(choose 1 of these 2 options)_

- [X] I assign the copyright on this contribution to Roberto Tyley
- [ ] I disclaim copyright and thus place this contribution in the public domain

