### PR TITLE
Fixes #285, broken download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ Roberto's creations (<a href="https://play.google.com/store/apps/details?id=com.
         </section>
 
         <aside id="sidebar">
-          <a id="download" class="button latest-download-link" data-event-category="Main download button" href="https://search.maven.org/remote_content?g=com.madgag&a=bfg&v=LATEST">
+          <a id="download" class="button latest-download-link" data-event-category="Main download button" href="https://search.maven.org/classic/remote_content?g=com.madgag&a=bfg&v=LATEST">
             <small>Download</small>
             <span class="latest-version">.jar file</span>
           </a>


### PR DESCRIPTION
Maven central updated their website and broke old links, adding a "classic" to the url fixes this link.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

- [ ] I assign the copyright on this contribution to Roberto Tyley
- [x] I disclaim copyright and thus place this contribution in the public domain

