### PR TITLE
Warn about PR problems in docs. Refs #16, #36, #350.

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,12 +75,22 @@ if (("rtyley.github.io" == window.location.host) && (window.location.protocol !=
 </ul>
 
 <h1 id="usage">Usage</h1>
+<p>
+  Make sure that local commits from all branches have been pushed. If you have protected
+  branches on the remote repo you will need to unlock them. Check that no PRs or issues
+  reference the commit you want to filter or any of its descendents@mdash;these hidden refs
+  will not be rewritten and the original commit will be retained
+  (a <a href="https://en.wikipedia.org/wiki/Merkle_tree">Merkel tree</a> win)!
+  All forks should be deleted.
+</p>
+
 <p>First clone a fresh copy of your repo, using the <a href="http://stackoverflow.com/q/3959924/438886"><code>--mirror</code></a> flag:</p>
 <pre><code>$ git clone --mirror git://example.com/some-big-repo.git
 </code></pre>
 <p>This is a <a href="http://git-scm.com/docs/gitglossary.html#def_bare_repository">bare</a>
 repo, which means your normal files won't be visible, but it is a <em>full</em> copy of the Git database of your repository, and at this point
-you should <strong>make a backup of it</strong> to ensure you don't lose anything.</p>
+you should <strong>make a backup of it</strong> to ensure you don't lose anything:</p>
+<pre><code>$ cp -rp some-big-repo.git some-big-repo-backup.git</code></pre>
 <p>Now you can run the BFG to clean your repository up:</p>
 <pre><code>$ java -jar <a class="latest-download-link" data-event-category="Java command" href="#download">bfg.jar</a> --strip-blobs-bigger-than 100M some-big-repo.git
 </code></pre>
@@ -90,7 +100,33 @@ $ git reflog expire --expire=now --all && git gc --prune=now --aggressive
 </code></pre>
 <p>Finally, once you're happy with the updated state of your repo, push it back up <em>(note that because your clone command used the <code>--mirror</code> flag, this push will update <strong>all</strong> refs on your remote server)</em>:</p>
 <pre><code>$ git push</code></pre>
-<p>At this point, you're ready for everyone to ditch their old copies of the repo and do fresh clones of the nice, new pristine data. It's best to delete all old clones, as they'll have dirty history that you <i>don't</i> want to risk pushing back into your newly cleaned repo.
+<p>If you have protected branches on your remote repository you will see an error like the following:</p>
+<pre><code>! [remote rejected] master -> master (pre-receive hook declined)</code></pre>
+<p>Unlock them and try again. Pull requests will cause similar errors:</p>
+<pre><code>! [remote rejected] refs/pull/957/head -> refs/pull/957/head (hook declined)</code></pre>
+<p>
+  though in this case the references are hidden and cannot be rewritten.  Instead, for each PR
+  you will need to replay the commits against the new repo. Find the commit hash in the old repo
+  where the PR initially branched and the corresponding commit hash in the new repo. A simple
+  rebase should be enough except when your working branch has merge commits. In that case you
+  will then need to cherry-pick the commits into the new repo, replacing merge commits with
+  merges from the new repo. After updating the PRs you may need to rerun the garbage collector.
+  If your remote still contains the unfiltered commits, contact your remote repository
+  administrator for assistance. See issues
+  <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/16">#16</a>,
+  <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/36">#36</a>, and
+  <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/350">#350</a>
+  for more information.
+</p>
+
+<p>
+  At this point, you're ready for everyone to ditch their old copies of the repo and do fresh
+  clones of the nice, new pristine data. It's best to reclone the repo, as the existing clones
+  will have dirty history that you <i>don't</i> want to risk pushing back into your newly
+  cleaned repo. If the old clones have local commits, then you should be able to rebase
+  them onto the corresponding commit hash from the new repo much like you did for pull
+  requests.  Be prepared for zombie commits popping up from time to time via pull requests
+  from a fork, or from developers who have old copies of the repo lying around on various machines.
 </p>
 
 <h1 id="examples">Examples</h1>

--- a/index.html
+++ b/index.html
@@ -105,14 +105,7 @@ $ git reflog expire --expire=now --all && git gc --prune=now --aggressive
 <p>Unlock them and try again. Pull requests will cause similar errors:</p>
 <pre><code>! [remote rejected] refs/pull/957/head -> refs/pull/957/head (hook declined)</code></pre>
 <p>
-  though in this case the references are hidden and cannot be rewritten.  Instead, for each PR
-  you will need to replay the commits against the new repo. Find the commit hash in the old repo
-  where the PR initially branched and the corresponding commit hash in the new repo. A simple
-  rebase should be enough except when your working branch has merge commits. In that case you
-  will then need to cherry-pick the commits into the new repo, replacing merge commits with
-  merges from the new repo. After updating the PRs you may need to rerun the garbage collector.
-  If your remote still contains the unfiltered commits, contact your remote repository
-  administrator for assistance. See issues
+  though in this case the references are hidden and cannot be rewritten. See issues
   <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/16">#16</a>,
   <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/36">#36</a>, and
   <a href="https://github.com/rtyley/bfg-repo-cleaner/issues/350">#350</a>
@@ -123,10 +116,10 @@ $ git reflog expire --expire=now --all && git gc --prune=now --aggressive
   At this point, you're ready for everyone to ditch their old copies of the repo and do fresh
   clones of the nice, new pristine data. It's best to reclone the repo, as the existing clones
   will have dirty history that you <i>don't</i> want to risk pushing back into your newly
-  cleaned repo. If the old clones have local commits, then you should be able to rebase
-  them onto the corresponding commit hash from the new repo much like you did for pull
-  requests.  Be prepared for zombie commits popping up from time to time via pull requests
-  from a fork, or from developers who have old copies of the repo lying around on various machines.
+  cleaned repo. If the old clones have local commits then you should be able to replay
+  them onto the corresponding commit hash from the new repo. Be prepared for zombie commits
+  popping up from time to time via pull requests from a fork, or from developers who have
+  old copies of the repo lying around on various machines.
 </p>
 
 <h1 id="examples">Examples</h1>


### PR DESCRIPTION
I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

_(choose 1 of these 2 options)_

- [ ] I assign the copyright on this contribution to Roberto Tyley
- [X] I disclaim copyright and thus place this contribution in the public domain

I ran BFG on a repo with pull requests, which was ultimately not useful since the history I was trying to remove is still accessible.  This is already reported in #16, #36, #350. I want to warn future me (and other users) that this was the case so I updated the docs.

I suggest rebasing all dependent PRs on the revised commit hashes. I have not yet tried it but it ought to help.