### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ alternative to `git-filter-branch` for cleansing bad data out of your Git reposi
 * Removing **Passwords, Credentials** & other **Private data**
 
 Main documentation for The BFG is here : **https://rtyley.github.io/bfg-repo-cleaner/**
+
+First clone a fresh copy of your repo, using the **--bare** flag:
+
+$ git clone --bare git://example.com/some-big-repo.git
+


### PR DESCRIPTION
Here's a suggestion for change in main documentation on https://rtyley.github.io/bfg-repo-cleaner/.
Reason: 
*--bare* flag mirrors a repository without pull requests, which solves a problem with pushing a branch containing refs back to GitHub va git. 
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/duplicating-a-repository

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

_(choose 1 of these 2 options)_

- [ ] I assign the copyright on this contribution to Roberto Tyley
- [ + ] I disclaim copyright and thus place this contribution in the public domain

