### PR TITLE
Upgrade to Scala v2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 dist: xenial
 scala:
-   - 2.12.12
+   - 2.13.4
 
 jdk:
   - openjdk8

--- a/bfg-benchmark/build.sbt
+++ b/bfg-benchmark/build.sbt
@@ -1,8 +1,7 @@
 import Dependencies._
 
-libraryDependencies ++= Seq(
+libraryDependencies ++= guava ++ Seq(
   madgagCompress,
-  scalaIoFile,
   textmatching,
   scopt
 )

--- a/bfg-benchmark/src/main/scala/lib/Repo.scala
+++ b/bfg-benchmark/src/main/scala/lib/Repo.scala
@@ -1,23 +1,26 @@
 package lib
 
+import com.google.common.io.MoreFiles
+import com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE
 import com.madgag.compress.CompressUtil._
 
-import scalax.file.ImplicitConversions._
-import scalax.file.Path
-import scalax.file.defaultfs.DefaultPath
+import java.nio.file.{Files, Path}
+import scala.util.Using
 
-class RepoExtractor(scratchDir: DefaultPath) {
+class RepoExtractor(scratchDir: Path) {
 
-  val repoDir = scratchDir / "repo.git"
+  val repoDir = scratchDir.resolve( "repo.git")
 
   def extractRepoFrom(zipPath: Path) = {
-    repoDir.deleteRecursively(force = true)
+    if (Files.exists(repoDir)) MoreFiles.deleteRecursively(repoDir, ALLOW_INSECURE)
 
-    repoDir.createDirectory()
+    Files.createDirectories(repoDir)
 
-    println(s"Extracting repo to ${repoDir.toAbsolute.path}")
+    println(s"Extracting repo to ${repoDir.toAbsolutePath}")
 
-    zipPath.inputStream.acquireFor { stream => unzip(stream, repoDir) }
+    Using(Files.newInputStream(zipPath)) {
+      stream => unzip(stream, repoDir.toFile)
+    }
 
     repoDir
   }

--- a/bfg-benchmark/src/main/scala/model/BFGJar.scala
+++ b/bfg-benchmark/src/main/scala/model/BFGJar.scala
@@ -1,6 +1,6 @@
 package model
 
-import scalax.file.Path
+import java.nio.file.Path
 
 object BFGJar {
   def from(path: Path) = BFGJar(path, Map.empty)

--- a/bfg-benchmark/src/main/scala/model/InvocableEngineSet.scala
+++ b/bfg-benchmark/src/main/scala/model/InvocableEngineSet.scala
@@ -1,14 +1,14 @@
 package model
 
-import scalax.file.Path
-import scalax.file.defaultfs.DefaultPath
+import java.io.File
+import java.nio.file.Path
 
 case class InvocableEngineSet[InvocationArgs <: EngineInvocation](
   engineType: EngineType[InvocationArgs],
   invocableEngines: Seq[InvocableEngine[InvocationArgs]]
 ) {
 
-  def invocationsFor(commandDir: Path): Seq[(InvocableEngine[InvocationArgs], DefaultPath => scala.sys.process.ProcessBuilder)] = {
+  def invocationsFor(commandDir: Path): Seq[(InvocableEngine[InvocationArgs], File => scala.sys.process.ProcessBuilder)] = {
     for {
       args <- engineType.argsOptsFor(commandDir).toSeq
       invocable <- invocableEngines

--- a/bfg-benchmark/src/test/scala/JavaVersionSpec.scala
+++ b/bfg-benchmark/src/test/scala/JavaVersionSpec.scala
@@ -1,4 +1,6 @@
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 object JavaVersionSpec extends AnyFlatSpec with OptionValues with Matchers {
   "version" should "parse an example line" in {

--- a/bfg-library/build.sbt
+++ b/bfg-library/build.sbt
@@ -1,4 +1,14 @@
 import Dependencies._
 
-libraryDependencies ++= guava :+ scalaIoFile :+ textmatching :+ scalaGit :+ jgit :+ slf4jSimple :+ scalaGitTest % "test"
+libraryDependencies ++= guava ++ Seq(
+  parCollections,
+  scalaCollectionPlus,
+  textmatching,
+  scalaGit,
+  jgit,
+  slf4jSimple,
+  lineSplitting,
+  scalaGitTest % Test,
+  "org.apache.commons" % "commons-text" % "1.9" % Test
+)
 

--- a/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentMultiMap.scala
+++ b/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentMultiMap.scala
@@ -20,6 +20,7 @@
 
 package com.madgag.collection.concurrent
 
+import com.madgag.scala.collection.decorators._
 
 class ConcurrentMultiMap[A, B] {
 
@@ -34,5 +35,5 @@ class ConcurrentMultiMap[A, B] {
     this
   }
 
-  def toMap: Map[A, Set[B]] = m.toMap.mapValues(_.toSet)
+  def toMap: Map[A, Set[B]] = m.toMap.mapV(_.toSet)
 }

--- a/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentSet.scala
+++ b/bfg-library/src/main/scala/com/madgag/collection/concurrent/ConcurrentSet.scala
@@ -20,29 +20,53 @@
 
 package com.madgag.collection.concurrent
 
-import scala.collection.mutable.{Set, SetLike}
+import scala.collection.mutable.{AbstractSet, SetOps}
+import scala.collection.{IterableFactory, IterableFactoryDefaults, mutable}
 
-
-class ConcurrentSet[A] extends Set[A] with SetLike[A, ConcurrentSet[A]] {
+class ConcurrentSet[A]()
+  extends AbstractSet[A]
+    with SetOps[A, ConcurrentSet, ConcurrentSet[A]]
+    with IterableFactoryDefaults[A, ConcurrentSet]
+{
 
   val m: collection.concurrent.Map[A, Boolean] = collection.concurrent.TrieMap.empty
 
-  override def +=(elem: A): this.type = {
+  override def iterableFactory: IterableFactory[ConcurrentSet] = ConcurrentSet
+
+  override def clear(): Unit = m.clear()
+
+  override def addOne(elem: A): ConcurrentSet.this.type = {
     m.put(elem, true)
     this
   }
 
-  override def -=(elem: A): this.type = {
+  override def subtractOne(elem: A): ConcurrentSet.this.type = {
     m.remove(elem)
-    this
-  }
-
-  override def empty: this.type = {
-    m.empty
     this
   }
 
   override def contains(elem: A): Boolean = m.contains(elem)
 
   override def iterator: Iterator[A] = m.keysIterator
+
+}
+
+object ConcurrentSet extends IterableFactory[ConcurrentSet] {
+
+  @transient
+  private final val EmptySet = new ConcurrentSet()
+
+  def empty[A]: ConcurrentSet[A] = EmptySet.asInstanceOf[ConcurrentSet[A]]
+
+  def from[A](source: collection.IterableOnce[A]): ConcurrentSet[A] =
+    source match {
+      case hs: ConcurrentSet[A] => hs
+      case _ if source.knownSize == 0 => empty[A]
+      case _ => (newBuilder[A] ++= source).result()
+    }
+
+  /** Create a new Builder which can be reused after calling `result()` without an
+   * intermediate call to `clear()` in order to build multiple related results.
+   */
+  def newBuilder[A]: mutable.Builder[A, ConcurrentSet[A]] = ???
 }

--- a/bfg-library/src/main/scala/com/madgag/git/LFS.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/LFS.scala
@@ -20,34 +20,34 @@
 
 package com.madgag.git
 
-import java.nio.charset.Charset
-import java.security.{DigestOutputStream, MessageDigest}
-
 import com.google.common.base.Splitter
 import com.madgag.git.bfg.model.FileName
 import org.apache.commons.codec.binary.Hex._
 import org.eclipse.jgit.lib.ObjectLoader
 
-import scala.collection.JavaConverters._
-import scalax.file.Path
-import scalax.file.defaultfs.DefaultPath
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+import java.security.{DigestOutputStream, MessageDigest}
+import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 object LFS {
 
-  val ObjectsPath = Path("lfs" , "objects")
+  val ObjectsPath: Seq[String] = Seq("lfs" , "objects")
 
-  val PointerCharset = Charset.forName("UTF-8")
+  val PointerCharset: Charset = UTF_8
 
   case class Pointer(shaHex: String, blobSize: Long) {
 
-    lazy val text = s"""|version https://git-lfs.github.com/spec/v1
-                        |oid sha256:$shaHex
-                        |size $blobSize
-                        |""".stripMargin
+    lazy val text: String = s"""|version https://git-lfs.github.com/spec/v1
+                                |oid sha256:$shaHex
+                                |size $blobSize
+                                |""".stripMargin
 
-    lazy val bytes = text.getBytes(PointerCharset)
+    lazy val bytes: Array[Byte] = text.getBytes(PointerCharset)
 
-    lazy val path = Path(shaHex.substring(0, 2), shaHex.substring(2, 4), shaHex)
+    lazy val path: Seq[String] = Seq(shaHex.substring(0, 2), shaHex.substring(2, 4), shaHex)
   }
 
   object Pointer {
@@ -65,12 +65,12 @@ object LFS {
 
   val GitAttributesFileName = FileName(".gitattributes")
 
-  def pointerFor(loader: ObjectLoader, tmpFile: DefaultPath) = {
+  def pointerFor(loader: ObjectLoader, tmpFile: Path) = {
     val digest = MessageDigest.getInstance("SHA-256")
 
-    for {
-      outStream <- tmpFile.outputStream()
-    } loader.copyTo(new DigestOutputStream(outStream, digest))
+    Using(Files.newOutputStream(tmpFile)) { outStream =>
+      loader.copyTo(new DigestOutputStream(outStream, digest))
+    }
 
     Pointer(encodeHexString(digest.digest()), loader.getSize)
   }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobCharsetDetector.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/BlobCharsetDetector.scala
@@ -20,36 +20,38 @@
 
 package com.madgag.git.bfg.cleaner
 
+import com.google.common.io.ByteStreams
+import com.google.common.io.ByteStreams.toByteArray
+import com.madgag.git.bfg.model.TreeBlobEntry
+import org.eclipse.jgit.diff.RawText
+import org.eclipse.jgit.lib.ObjectLoader
+
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction._
-
-import com.madgag.git.bfg.model.TreeBlobEntry
-import org.eclipse.jgit.diff.RawText
-import org.eclipse.jgit.lib.ObjectStream
-
-import scala.util.Try
-import scalax.io.managed.InputStreamResource
+import scala.util.{Try, Using}
 
 
 trait BlobCharsetDetector {
   // should return None if this is a binary file that can not be converted to text
-  def charsetFor(entry: TreeBlobEntry, streamResource: InputStreamResource[ObjectStream]): Option[Charset]
+  def charsetFor(entry: TreeBlobEntry, objectLoader: ObjectLoader): Option[Charset]
 }
 
 
 object QuickBlobCharsetDetector extends BlobCharsetDetector {
 
-  val CharSets = Seq(Charset.forName("UTF-8"), Charset.defaultCharset(), Charset.forName("ISO-8859-1")).distinct
+  val CharSets: Seq[Charset] =
+    Seq(Charset.forName("UTF-8"), Charset.defaultCharset(), Charset.forName("ISO-8859-1")).distinct
 
-  def charsetFor(entry: TreeBlobEntry, streamResource: InputStreamResource[ObjectStream]): Option[Charset] =
-    Some(streamResource.bytes.take(8000).toArray).filterNot(RawText.isBinary).flatMap {
+  def charsetFor(entry: TreeBlobEntry, objectLoader: ObjectLoader): Option[Charset] = {
+    Using(ByteStreams.limit(objectLoader.openStream(), 8000))(toByteArray).toOption.filterNot(RawText.isBinary).flatMap {
       sampleBytes =>
         val b = ByteBuffer.wrap(sampleBytes)
         CharSets.find(cs => Try(decode(b, cs)).isSuccess)
     }
+  }
 
-  private def decode(b: ByteBuffer, charset: Charset) {
+  private def decode(b: ByteBuffer, charset: Charset): Unit = {
     charset.newDecoder.onMalformedInput(REPORT).onUnmappableCharacter(REPORT).decode(b)
   }
 }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala
@@ -20,8 +20,8 @@
 
 package com.madgag.git.bfg.cleaner
 
-import java.nio.charset.Charset
-
+import com.google.common.io.ByteSource
+import com.google.common.io.Files.createParentDirs
 import com.madgag.git.LFS._
 import com.madgag.git._
 import com.madgag.git.bfg.model._
@@ -30,17 +30,17 @@ import com.madgag.textmatching.{Glob, TextMatcher}
 import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.eclipse.jgit.lib.{ObjectId, ObjectReader}
 
-import scala.util.Try
-import scalax.file.ImplicitConversions._
-import scalax.file.Path.createTempFile
-import scalax.io.JavaConverters._
+import java.nio.charset.Charset
+import java.nio.file.{Files, Path}
+import scala.jdk.StreamConverters._
+import scala.util.{Try, Using}
 
 class LfsBlobConverter(
   lfsGlobExpression: String,
   repo: FileRepository
 ) extends TreeBlobModifier {
 
-  val lfsObjectsDir = repo.getDirectory / LFS.ObjectsPath
+  val lfsObjectsDir: Path = repo.getDirectory.toPath.resolve(LFS.ObjectsPath)
 
   val threadLocalObjectDBResources = repo.getObjectDatabase.threadLocalResources
 
@@ -67,11 +67,12 @@ class LfsBlobConverter(
     } {
       case (_, oldGitAttributesId) =>
         val objectLoader = threadLocalObjectDBResources.reader().open(oldGitAttributesId)
-        val oldAttributes = objectLoader.getCachedBytes.asInput.lines().toSeq
-
-        if (oldAttributes.contains(gitAttributesLine)) oldGitAttributesId else {
-          storeBlob((oldAttributes :+ gitAttributesLine).mkString("\n"))
-        }
+        Using(ByteSource.wrap(objectLoader.getCachedBytes).asCharSource(UTF_8).lines()) { oldAttributesStream =>
+          val oldAttributes = oldAttributesStream.toScala(Seq)
+          if (oldAttributes.contains(gitAttributesLine)) oldGitAttributesId else {
+            storeBlob((oldAttributes :+ gitAttributesLine).mkString("\n"))
+          }
+        }.get
     }
     cleanedBlobs.copy(entryMap = cleanedBlobs.entryMap + (GitAttributesFileName -> (RegularFile, newGitAttributesId)))
   }
@@ -94,17 +95,19 @@ class LfsBlobConverter(
   def tryStoringLfsFileFor(blobId: ObjectId)(implicit r: ObjectReader): Try[Pointer] = {
     val loader = blobId.open
     
-    val tmpFile = createTempFile(s"bfg.git-lfs.conv-${blobId.name}")
+    val tmpFile: Path = Files.createTempFile(s"bfg.git-lfs.conv-${blobId.name}","dat")
     
     val pointer = pointerFor(loader, tmpFile)
 
-    val lfsPath = lfsObjectsDir / pointer.path
+    val lfsPath = lfsObjectsDir.resolve(pointer.path)
 
-    val ensureLfsFile = Try(if (!lfsPath.exists) tmpFile moveTo lfsPath).recover {
-      case _ if lfsPath.size.contains(loader.getSize) =>
+    createParentDirs(lfsPath.toFile)
+
+    val ensureLfsFile = Try(if (!Files.exists(lfsPath)) Files.move(tmpFile, lfsPath)).recover {
+      case _ if Files.exists(lfsPath) && Files.size(lfsPath) == loader.getSize =>
     }
 
-    Try(tmpFile.delete(force = true))
+    Try(Files.deleteIfExists(tmpFile))
 
     ensureLfsFile.map(_ => pointer)
   }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/ObjectIdCleaner.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/ObjectIdCleaner.scala
@@ -139,7 +139,7 @@ class ObjectIdCleaner(config: ObjectIdCleaner.Config, objectDB: ObjectDatabase, 
     }
   }
 
-  def recordChange(originalBlobs: TreeBlobs, fixedTreeBlobs: TreeBlobs) {
+  def recordChange(originalBlobs: TreeBlobs, fixedTreeBlobs: TreeBlobs): Unit = {
     val changedFiles: Set[TreeBlobEntry] = originalBlobs.entries.toSet -- fixedTreeBlobs.entries.toSet
     for (TreeBlobEntry(filename, _, oldId) <- changedFiles) {
       fixedTreeBlobs.objectId(filename) match {

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/protection/ProtectedObjectCensus.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/protection/ProtectedObjectCensus.scala
@@ -21,6 +21,7 @@
 package com.madgag.git.bfg.cleaner.protection
 
 import com.madgag.git._
+import com.madgag.scala.collection.decorators._
 import org.eclipse.jgit.lib.{ObjectId, Repository}
 import org.eclipse.jgit.revwalk._
 
@@ -72,7 +73,7 @@ object ProtectedObjectCensus {
     // blobs come from direct blob references and tag references
     // trees come from direct tree references, commit & tag references
 
-    val treeAndBlobProtection = objectProtection.keys.groupBy(treeOrBlobPointedToBy).mapValues(_.toSet) // use Either?
+    val treeAndBlobProtection = objectProtection.keys.groupUp(treeOrBlobPointedToBy)(_.toSet) // use Either?
 
     val directBlobProtection = treeAndBlobProtection collect {
       case (Left(blob), p) => blob.getId -> p
@@ -80,7 +81,7 @@ object ProtectedObjectCensus {
     val treeProtection = treeAndBlobProtection collect {
       case (Right(tree), p) => tree -> p
     }
-    val indirectBlobProtection = treeProtection.keys.flatMap(tree => allBlobsUnder(tree).map(_ -> tree)).groupBy(_._1).mapValues(_.map(_._2).toSet)
+    val indirectBlobProtection = treeProtection.keys.flatMap(tree => allBlobsUnder(tree).map(_ -> tree)).groupUp(_._1)(_.map(_._2).toSet)
 
     ProtectedObjectCensus(objectProtection, treeProtection, directBlobProtection, indirectBlobProtection)
   }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/protection/ProtectedObjectDirtReport.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/protection/ProtectedObjectDirtReport.scala
@@ -30,7 +30,7 @@ import org.eclipse.jgit.revwalk.{RevObject, RevWalk}
 import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.TreeFilter
 
-import scala.collection.convert.ImplicitConversionsToScala._
+import scala.jdk.CollectionConverters._
 
 object ProtectedObjectDirtReport {
   def reportsFor(objectIdCleanerConfig: ObjectIdCleaner.Config, objectDB: ObjectDatabase)(implicit revWalk: RevWalk) = {
@@ -68,6 +68,6 @@ case class ProtectedObjectDirtReport(revObject: RevObject, originalTreeOrBlob: R
     tw.addTree(originalTreeOrBlob.asRevTree)
     tw.addTree(newId.asRevTree)
     tw.setFilter(TreeFilter.ANY_DIFF)
-    DiffEntry.scan(tw).filterNot(_.getChangeType == ADD)
+    DiffEntry.scan(tw).asScala.filterNot(_.getChangeType == ADD).toSeq
   }
 }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/memo.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/memo.scala
@@ -20,10 +20,9 @@
 
 package com.madgag.git.bfg
 
+import scala.jdk.CollectionConverters._
 import com.google.common.cache.{CacheBuilder, CacheLoader, CacheStats, LoadingCache}
 import com.madgag.git.bfg.cleaner._
-
-import scala.collection.JavaConverters._
 
 trait Memo[K, V] {
   def apply(z: K => V): MemoFunc[K, V]
@@ -50,7 +49,7 @@ object MemoUtil {
       (f: Cleaner[V]) =>
         lazy val permanentCache = loaderCacheFor(f)(fix)
 
-        def fix(v: V) {
+        def fix(v: V): Unit = {
           // enforce that once any value is returned, it is 'good' and therefore an identity-mapped key as well
           permanentCache.put(v, v)
         }

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/model/Commit.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/model/Commit.scala
@@ -1,14 +1,13 @@
 package com.madgag.git.bfg.model
 
-import java.nio.charset.{Charset, IllegalCharsetNameException, UnsupportedCharsetException}
-
 import com.madgag.git._
 import com.madgag.git.bfg.cleaner._
 import org.eclipse.jgit.lib.Constants.OBJ_COMMIT
 import org.eclipse.jgit.lib._
 import org.eclipse.jgit.revwalk.RevCommit
 
-import scala.collection.convert.ImplicitConversionsToJava
+import java.nio.charset.{Charset, IllegalCharsetNameException, UnsupportedCharsetException}
+import scala.jdk.CollectionConverters._
 
 /*
  * Copyright (c) 2012, 2013 Roberto Tyley
@@ -37,10 +36,8 @@ object Commit {
 
 case class Commit(node: CommitNode, arcs: CommitArcs) {
   def toBytes: Array[Byte] = {
-    import ImplicitConversionsToJava._
-
     val c = new CommitBuilder
-    c.setParentIds(arcs.parents)
+    c.setParentIds(arcs.parents.asJava)
     c.setTreeId(arcs.tree)
 
     c.setAuthor(node.author)
@@ -66,7 +63,7 @@ object CommitNode {
 }
 
 case class CommitNode(author: PersonIdent, committer: PersonIdent, message: String, encoding: Charset = Constants.CHARSET) {
-  lazy val subject = message.linesIterator.toStream.headOption
+  lazy val subject = message.linesIterator.to(LazyList).headOption
   lazy val lastParagraphBreak = message.lastIndexOf("\n\n")
   lazy val messageWithoutFooters = if (footers.isEmpty) message else (message take lastParagraphBreak)
   lazy val footers: List[Footer] = message.drop(lastParagraphBreak).linesIterator.collect {

--- a/bfg-library/src/main/scala/com/madgag/git/bfg/model/package.scala
+++ b/bfg-library/src/main/scala/com/madgag/git/bfg/model/package.scala
@@ -22,9 +22,15 @@ package com.madgag.git.bfg
 
 import org.eclipse.jgit.revwalk.RevCommit
 
+import java.nio.file.Path
+
 
 package object model {
   implicit class RichRevCommit(revCommit: RevCommit) {
-    lazy val arcs = CommitArcs(revCommit.getParents, revCommit.getTree)
+    lazy val arcs: CommitArcs = CommitArcs(revCommit.getParents.toIndexedSeq, revCommit.getTree)
+  }
+
+  implicit class RichPath(path: Path) {
+    def resolve(pathSegments: Seq[String]): Path = pathSegments.foldLeft(path)(_ resolve _)
   }
 }

--- a/bfg-library/src/main/scala/com/madgag/text/ByteSize.scala
+++ b/bfg-library/src/main/scala/com/madgag/text/ByteSize.scala
@@ -33,10 +33,8 @@ object ByteSize {
   }
 
   def format(bytes: Long): String = {
-    if (bytes < unit) {
-      bytes + " B"
-    } else {
-      val exp = (log(bytes) / log(unit)).toInt
+    if (bytes < unit) s"$bytes B " else {
+      val exp = (log(bytes.toDouble) / log(unit)).toInt
       val pre = magnitudeChars(exp)
       "%.1f %sB".format(bytes / pow(unit, exp), pre)
     }

--- a/bfg-library/src/main/scala/com/madgag/text/text.scala
+++ b/bfg-library/src/main/scala/com/madgag/text/text.scala
@@ -20,11 +20,9 @@
 
 package com.madgag.text
 
-import scala.collection.GenTraversableOnce
-
 object Text {
 
-  def abbreviate[A](elems: Traversable[A], truncationToken: A, maxElements: Int = 3) = {
+  def abbreviate[A](elems: Iterable[A], truncationToken: A, maxElements: Int = 3) = {
     val firstElems = elems.take(maxElements + 1)
     if (firstElems.size > maxElements) {
       firstElems.take(maxElements-1).toSeq :+ truncationToken
@@ -33,5 +31,5 @@ object Text {
     }
   }
 
-  def plural[A](list: GenTraversableOnce[A], noun: String) = list.size + " " + noun + (if (list.size == 1) "" else "s")
+  def plural[A](list: Iterable[A], noun: String) = s"${list.size} $noun${if (list.size == 1) "" else "s"}"
 }

--- a/bfg-library/src/test/scala/com/madgag/git/LFSSpec.scala
+++ b/bfg-library/src/test/scala/com/madgag/git/LFSSpec.scala
@@ -27,8 +27,9 @@ import org.eclipse.jgit.lib.ObjectInserter
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import scalax.file.Path
-import scalax.file.Path._
+
+import java.nio.file.Files
+import java.nio.file.Files.createTempFile
 
 class LFSSpec extends AnyFlatSpec with Matchers with OptionValues {
   "Our implementation of Git LFS Pointers" should "create pointers that have the same Git id as the ones produced by `git lfs pointer`" in {
@@ -42,19 +43,19 @@ class LFSSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "have the correctly sharded path" in {
     val pointer = LFS.Pointer("b2893eddd9b394bfb7efadafda2ae0be02c573fdd83a70f26c781a943f3b7016", 21616)
 
-    pointer.path shouldBe Path("b2", "89", "b2893eddd9b394bfb7efadafda2ae0be02c573fdd83a70f26c781a943f3b7016")
+    pointer.path shouldBe Seq("b2", "89", "b2893eddd9b394bfb7efadafda2ae0be02c573fdd83a70f26c781a943f3b7016")
   }
 
   it should "calculate pointers correctly directly from the Git database, creating a temporary file" in {
     implicit val repo = unpackRepo("/sample-repos/example.git.zip")
     implicit val (revWalk, reader) = repo.singleThreadedReaderTuple
 
-    val tmpFile = createTempFile(s"bfg.test.git-lfs.conv")
+    val tmpFile = createTempFile(s"bfg.test.git-lfs",".conv")
 
     val pointer = LFS.pointerFor(abbrId("06d7").open, tmpFile)
 
     pointer shouldBe Pointer("5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef", 1024)
 
-    tmpFile.size.value shouldBe 1024
+    Files.size(tmpFile) shouldBe 1024
   }
 }

--- a/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/ObjectIdCleanerSpec.scala
+++ b/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/ObjectIdCleanerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.Matcher
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.convert.ImplicitConversionsToScala._
+import scala.jdk.CollectionConverters._
 
 class ObjectIdCleanerSpec extends AnyFlatSpec with Matchers {
   
@@ -52,9 +52,9 @@ class unpackedRepo(filePath: String) extends bfg.test.unpackedRepo(filePath) {
   class EnsureCleanerWith(config: ObjectIdCleaner.Config) {
 
     class RemoveDirtOfCommitsThat(commitM: Matcher[RevCommit]) extends Inspectors with Matchers {
-      def histOf(c: ObjectId) = repo.git.log.add(c).call.toSeq.reverse
+      def histOf(c: ObjectId) = repo.git.log.add(c).call.asScala.toSeq.reverse
 
-      def whenCleaning(oldCommit: ObjectId) {
+      def whenCleaning(oldCommit: ObjectId): Unit = {
         val cleaner = new ObjectIdCleaner(config, repo.getObjectDatabase, revWalk)
         forAtLeast(1, histOf(oldCommit)) { commit =>
           commit should commitM

--- a/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/TreeBlobModifierSpec.scala
+++ b/bfg-library/src/test/scala/com/madgag/git/bfg/cleaner/TreeBlobModifierSpec.scala
@@ -28,7 +28,7 @@ import com.madgag.git.test._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.convert.ImplicitConversionsToScala._
+import scala.jdk.CollectionConverters._
 
 class TreeBlobModifierSpec extends AnyFlatSpec with Matchers {
 
@@ -48,7 +48,7 @@ class TreeBlobModifierSpec extends AnyFlatSpec with Matchers {
 
     RepoRewriter.rewrite(repo, ObjectIdCleaner.Config(ProtectedObjectCensus(Set("HEAD")), OldIdsPublic, treeBlobsCleaners = Seq(countingTreeBlobModifier)))
 
-    val endCounts = countingTreeBlobModifier.counts.asMap().toMap
+    val endCounts = countingTreeBlobModifier.counts.asMap().asScala.toMap
 
     endCounts.size should be >= 4
     all (endCounts.values) shouldBe 1

--- a/bfg-test/src/main/scala/com/madgag/git/bfg/test/unpackedRepo.scala
+++ b/bfg-test/src/main/scala/com/madgag/git/bfg/test/unpackedRepo.scala
@@ -12,7 +12,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
-import scala.collection.convert.ImplicitConversionsToScala._
+import scala.jdk.CollectionConverters._
 
 class unpackedRepo(filePath: String) extends AnyFlatSpec with Matchers {
 
@@ -66,9 +66,9 @@ class unpackedRepo(filePath: String) extends AnyFlatSpec with Matchers {
   def commitHist(specificRefs: String*)(implicit repo: Repository): Seq[RevCommit] = {
     val logCommand = repo.git.log
     if (specificRefs.isEmpty) logCommand.all else specificRefs.foldLeft(logCommand)((lc, ref) => lc.add(repo.resolve(ref)))
-  }.call.toSeq.reverse
+  }.call.asScala.toSeq.reverse
 
-  def haveCommitWhereObjectIds(boom: Matcher[Traversable[ObjectId]])(implicit reader: ObjectReader): Matcher[RevCommit] = boom compose {
+  def haveCommitWhereObjectIds(boom: Matcher[Iterable[ObjectId]])(implicit reader: ObjectReader): Matcher[RevCommit] = boom compose {
     (c: RevCommit) => c.getTree.walk().map(_.getObjectId(0)).toSeq
   }
 
@@ -84,7 +84,7 @@ class unpackedRepo(filePath: String) extends AnyFlatSpec with Matchers {
     r: Repository => commitHist(refs:_*)(r)
   }
 
-  def ensureRemovalOfBadEggs[S,T](expr : => Traversable[S], exprResultMatcher: Matcher[Traversable[S]])(block: => T) = {
+  def ensureRemovalOfBadEggs[S,T](expr : => Iterable[S], exprResultMatcher: Matcher[Iterable[S]])(block: => T) = {
     gc()
     expr should exprResultMatcher
 

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/CLIConfig.scala
@@ -20,8 +20,6 @@
 
 package com.madgag.git.bfg.cli
 
-import java.io.File
-
 import com.madgag.git.bfg.BuildInfo
 import com.madgag.git.bfg.GitUtil._
 import com.madgag.git.bfg.cleaner._
@@ -38,7 +36,9 @@ import org.eclipse.jgit.lib._
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import scopt.{OptionParser, Read}
 
-import scalax.file.ImplicitConversions._
+import java.io.File
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
 
 
 object CLIConfig {
@@ -54,6 +54,8 @@ object CLIConfig {
       }
     }
 
+    def readLinesFrom(v: File): Seq[String] = Files.readAllLines(v.toPath).asScala.toSeq
+
     val exactVersion = BuildInfo.version + (if (BuildInfo.version.contains("-SNAPSHOT")) s" (${BuildInfo.gitDescription})" else "")
 
     head("bfg", exactVersion)
@@ -66,7 +68,8 @@ object CLIConfig {
       (v, c) => c.copy(stripBiggestBlobs = Some(v))
     }
     opt[File]("strip-blobs-with-ids").abbr("bi").valueName("<blob-ids-file>").text("strip blobs with the specified Git object ids").action {
-      (v, c) => c.copy(stripBlobsWithIds = Some(v.lines().map(_.trim).filterNot(_.isEmpty).map(_.asObjectId).toSet))
+      (v, c) =>
+        c.copy(stripBlobsWithIds = Some(readLinesFrom(v).map(_.trim).filterNot(_.isEmpty).map(_.asObjectId).toSet))
     }
     fileMatcher("delete-files").abbr("D").text("delete files with the specified names (eg '*.class', '*.{txt,log}' - matches on file name, not path within repo)").action {
       (v, c) => c.copy(deleteFiles = Some(v))
@@ -80,7 +83,7 @@ object CLIConfig {
     opt[File]("replace-text").abbr("rt").valueName("<expressions-file>").text("filter content of files, replacing matched text. Match expressions should be listed in the file, one expression per line - " +
       "by default, each expression is treated as a literal, but 'regex:' & 'glob:' prefixes are supported, with '==>' to specify a replacement " +
       "string other than the default of '***REMOVED***'.").action {
-      (v, c) => c.copy(textReplacementExpressions = v.lines().filterNot(_.trim.isEmpty).toSeq)
+      (v, c) => c.copy(textReplacementExpressions = readLinesFrom(v).filterNot(_.trim.isEmpty))
     }
     fileMatcher("filter-content-including").abbr("fi").text("do file-content filtering on files that match the specified expression (eg '*.{txt,properties}')").action {
       (v, c) => c.copy(filenameFilters = c.filenameFilters :+ Include(v))
@@ -117,7 +120,7 @@ object CLIConfig {
 
         c.copy(fixFilenameDuplicatesPreferring = ord)
     }
-    arg[File]("<repo>") optional() action { (x, c) =>
+    arg[File]("<repo>").optional().action { (x, c) =>
       c.copy(repoLocation = x) } text("file path for Git repository to clean")
   }
 }
@@ -130,7 +133,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
                      fixFilenameDuplicatesPreferring: Option[Ordering[FileMode]] = None,
                      filenameFilters: Seq[Filter[String]] = Nil,
                      filterSizeThreshold: Long = BlobTextModifier.DefaultSizeThreshold,
-                     textReplacementExpressions: Traversable[String] = List.empty,
+                     textReplacementExpressions: Iterable[String] = List.empty,
                      stripBlobsWithIds: Option[Set[ObjectId]] = None,
                      lfsConversion: Option[String] = None,
                      strictObjectChecking: Boolean = false,
@@ -152,7 +155,7 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
 
   lazy val folderDeletion: Option[Cleaner[TreeSubtrees]] = deleteFolders.map {
     textMatcher => { subtrees: TreeSubtrees =>
-      TreeSubtrees(subtrees.entryMap.filterKeys(filename => !textMatcher(filename)))
+      TreeSubtrees(subtrees.entryMap.view.filterKeys(filename => !textMatcher(filename)).toMap)
     }
   }
 
@@ -201,8 +204,8 @@ case class CLIConfig(stripBiggestBlobs: Option[Int] = None,
       implicit val progressMonitor: ProgressMonitor = new TextProgressMonitor()
 
       val sizeBasedBlobTargetSources = Seq(
-        stripBlobsBiggerThan.map(threshold => (s: Stream[SizedObject]) => s.takeWhile(_.size > threshold)),
-        stripBiggestBlobs.map(num => (s: Stream[SizedObject]) => s.take(num))
+        stripBlobsBiggerThan.map(threshold => (s: LazyList[SizedObject]) => s.takeWhile(_.size > threshold)),
+        stripBiggestBlobs.map(num => (s: LazyList[SizedObject]) => s.take(num))
       ).flatten
 
       if (sizeBasedBlobTargetSources.isEmpty) None else {

--- a/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
+++ b/bfg/src/main/scala/com/madgag/git/bfg/cli/Main.scala
@@ -27,7 +27,7 @@ import com.madgag.git.bfg.cleaner._
 object Main extends App {
 
   if (args.isEmpty) {
-    CLIConfig.parser.showUsage
+    CLIConfig.parser.showUsage()
   } else {
 
     CLIConfig.parser.parse(args, CLIConfig()) map {
@@ -36,7 +36,7 @@ object Main extends App {
         tweakStaticJGitConfig(config.massiveNonFileObjects)
 
         if (config.gitdir.isEmpty) {
-          CLIConfig.parser.showUsage
+          CLIConfig.parser.showUsage()
           Console.err.println("Aborting : " + config.repoLocation + " is not a valid Git repository.\n")
         } else {
           implicit val repo = config.repo
@@ -52,7 +52,7 @@ object Main extends App {
 
           if (config.definesNoWork) {
             Console.err.println("Please specify tasks for The BFG :")
-            CLIConfig.parser.showUsage
+            CLIConfig.parser.showUsage()
           } else {
             println("Found " + config.objectProtection.fixedObjectIds.size + " objects to protect")
 

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
@@ -22,12 +22,14 @@ package com.madgag.git.bfg.cli
 
 import com.madgag.git._
 import com.madgag.git.bfg.cli.test.unpackedRepo
+import com.madgag.git.bfg.model._
 import org.eclipse.jgit.lib.ObjectId
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inspectors, OptionValues}
-import scalax.file.ImplicitConversions._
-import scalax.file.Path
+
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
 
 class MainSpec extends AnyFlatSpec with Matchers with OptionValues with Inspectors {
 
@@ -51,18 +53,18 @@ class MainSpec extends AnyFlatSpec with Matchers with OptionValues with Inspecto
   }
 
   "removing big blobs" should "definitely still remove blobs even if they have identical size" in new unpackedRepo("/sample-repos/moreThanOneBigBlobWithTheSameSize.git.zip") {
-    ensureRemovalOfBadEggs(packedBlobsOfSize(1024), (contain allElementsOf Set(abbrId("06d7"), abbrId("cb2c"))).matcher[Traversable[ObjectId]]) {
+    ensureRemovalOfBadEggs(packedBlobsOfSize(1024), (contain allElementsOf Set(abbrId("06d7"), abbrId("cb2c"))).matcher[Iterable[ObjectId]]) {
       run("--strip-blobs-bigger-than 512B")
     }
   }
 
   "converting to Git LFS" should "create a file in lfs/objects" in new unpackedRepo("/sample-repos/repoWithBigBlobs.git.zip") {
-    ensureRemovalOfBadEggs(packedBlobsOfSize(11238), (contain only abbrId("596c")).matcher[Traversable[ObjectId]]) {
+    ensureRemovalOfBadEggs(packedBlobsOfSize(11238), (contain only abbrId("596c")).matcher[Iterable[ObjectId]]) {
       run("--convert-to-git-lfs *.png --no-blob-protection")
     }
-    val lfsFile = repo.getDirectory / "lfs" / "objects" / "e0" / "eb" / "e0ebd49837a1cced34b9e7d3ff2fa68a8100df8f158f165ce139e366a941ba6e"
+    val lfsFile = repo.getDirectory.toPath.resolve(Seq("lfs", "objects", "e0", "eb", "e0ebd49837a1cced34b9e7d3ff2fa68a8100df8f158f165ce139e366a941ba6e"))
 
-    lfsFile.size.value shouldBe 11238
+    Files.size(lfsFile) shouldBe 11238
   }
 
   "removing a folder named '.git'" should "work" in new unpackedRepo("/sample-repos/badRepoContainingDotGitFolder.git.zip") {
@@ -91,11 +93,11 @@ class MainSpec extends AnyFlatSpec with Matchers with OptionValues with Inspecto
     implicit val r = reader
 
     val badBlobs = Set(abbrId("db59"), abbrId("86f9"))
-    val blobIdsFile = Path.createTempFile()
-    blobIdsFile.writeStrings(badBlobs.map(_.name()), "\n")
+    val blobIdsFile = Files.createTempFile("test-strip-blobs",".ids")
+    Files.write(blobIdsFile, badBlobs.map(_.name()).asJava)
 
     ensureRemovalFrom(commitHist()).ofCommitsThat(haveCommitWhereObjectIds(contain(abbrId("db59")))) {
-      run(s"--strip-blobs-with-ids ${blobIdsFile.path}")
+      run(s"--strip-blobs-with-ids $blobIdsFile")
     }
   }
 

--- a/bfg/src/test/scala/com/madgag/git/bfg/cli/test/unpackedRepo.scala
+++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/test/unpackedRepo.scala
@@ -24,7 +24,7 @@ import com.madgag.git.bfg
 import com.madgag.git.bfg.cli.Main
 
 class unpackedRepo(filePath: String) extends bfg.test.unpackedRepo(filePath) {
-  def run(options: String) {
+  def run(options: String): Unit = {
     Main.main(options.split(' ') :+ repo.getDirectory.getAbsolutePath)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import common._
 
 organization in ThisBuild := "com.madgag"
 
-scalaVersion in ThisBuild := "2.12.12"
+scalaVersion in ThisBuild := "2.13.4"
 
 scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-language:postfixOps")
 
@@ -27,11 +27,7 @@ lazy val bfg = bfgProject("bfg") enablePlugins(BuildInfoPlugin) dependsOn(bfgLib
 
 lazy val bfgBenchmark = bfgProject("bfg-benchmark")
 
-publishMavenStyle in ThisBuild := true
-
 publishTo in ThisBuild := sonatypePublishToBundle.value
-
-pomIncludeRepository in ThisBuild := { _ => false }
 
 pomExtra in ThisBuild := (
   <scm>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.4.7

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val scalaGitVersion = "4.0"
+  val scalaGitVersion = "4.3"
 
   val jgitVersionOverride = Option(System.getProperty("jgit.version"))
 
@@ -13,6 +13,10 @@ object Dependencies {
   // the 1.7.2 here matches slf4j-api in jgit's dependencies
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % "1.7.2"
 
+  val scalaCollectionPlus =  "com.madgag" %% "scala-collection-plus" % "0.5"
+
+  val parCollections = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0"
+
   val scalaGit = "com.madgag.scala-git" %% "scala-git" % scalaGitVersion exclude("org.eclipse.jgit", "org.eclipse.jgit")
 
   val scalaGitTest = "com.madgag.scala-git" %% "scala-git-test" % scalaGitVersion
@@ -21,14 +25,14 @@ object Dependencies {
 
   val madgagCompress = "com.madgag" % "util-compress" % "1.33"
 
-  val textmatching = "com.madgag" %% "scala-textmatching" % "2.3"
+  val textmatching = "com.madgag" %% "scala-textmatching" % "2.5"
 
   val scopt = "com.github.scopt" %% "scopt" % "3.7.1"
 
   val guava = Seq("com.google.guava" % "guava" % "30.1-jre", "com.google.code.findbugs" % "jsr305" % "2.0.3")
 
-  val scalaIoFile = "com.madgag" %% "scala-io-file" % "0.4.9"
-
   val useNewerJava =  "com.madgag" % "use-newer-java" % "0.1"
+
+  val lineSplitting = "com.madgag" %% "line-break-preserving-line-splitting" % "0.1.0"
 
 }


### PR DESCRIPTION
Key challenges with the upgrade:

* The [`scala-io`](https://github.com/jesseeichar/scala-io) library is not available for Scala 2.13 (I had custom-built the Scala 2.12 version, but it was too much effort to get it to 2.13). `scala-io` was providing several useful features:
  * streaming reading of character data with line-splitting that *preserves line-breaks* (because I don't want the BFG to change the line-breaks in your files while doing `--replace-text`). Finding a replacement library to do this wasn't easy - so much code seems to be based on [`java.io.BufferedReader`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html), which throws line-breaks away. `java.util.Scanner` can _maybe_ do it, but I couldn't get it to work! In the end, I implemented my own solution, a tiny library with a fairly decent set of tests: https://github.com/rtyley/line-break-preserving-line-splitting
  * resource management - mostly replaced by using Scala 2.13's [`Using`](https://www.scala-lang.org/api/current/scala/util/Using$.html).
  * File-path types and operations - mostly now performed by java.nio & Guava functions.
* Scala 2.13 has a [revised collections framework](https://docs.scala-lang.org/overviews/core/collections-migration-213.html), so:
  * BFG has its own `ConcurrentSet` which needs to be implemented in the new fashion
  * `Traversable` becomes `Iterable`, etc
