### PR TITLE
clearly mention the Java6 version still

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@ Roberto's creations (<a href="https://play.google.com/store/apps/details?id=com.
 </p>
 <h1>Requirements</h1>
 <ul>
-<li>The <a href="https://www.java.com/en/download/manual.jsp">Java Runtime Environment</a> (<b>Java 8</b> or above - BFG <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.16/bfg-1.12.16.jar">v1.12.16</a> was the last version to support Java 7)</li>
+<li>The <a href="https://www.java.com/en/download/manual.jsp">Java Runtime Environment</a> (<b>Java 8</b> or above - BFG <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.16/bfg-1.12.16.jar">v1.12.16</a> was the last version to support Java 7, <a href="http://repo1.maven.org/maven2/com/madgag/bfg/1.12.3/bfg-1.12.3.jar">v1.12.3</a> was the last version to support Java 6)</li>
 </ul>
 <p>That's it - the Scala library and all other dependencies are folded into the <a class="latest-download-link" data-event-category="Requirements Link" href="#download">downloadable jar</a>.</p>
 


### PR DESCRIPTION
it took me an hour to figure out, what version will work on SLES11 SP4  - which still carries Java 6.

I also considered putting a small table into the readme, pointing to the two last-supported versions and the releases page for the latest version.

I assert that this patch is my own work, and to [simplify the licensing of the BFG Repo-Cleaner](https://github.com/rtyley/bfg-repo-cleaner/blob/master/CONTRIBUTING.md#pull-requests):

- [x] I assign the copyright on this contribution to Roberto Tyley
- [ ] I disclaim copyright and thus place this contribution in the public domain

